### PR TITLE
Optimize stack restoration.

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -155,6 +155,7 @@ namespace {
     int InvokeState; // cycles between 0, 1 after preInvoke, 2 after call, 0 again after postInvoke. hackish, no argument there.
     CodeGenOpt::Level OptLevel;
     const DataLayout *DL;
+    bool StackBumped;
 
     #include "CallHandlers.h"
 
@@ -162,7 +163,7 @@ namespace {
     static char ID;
     JSWriter(formatted_raw_ostream &o, CodeGenOpt::Level OptLevel)
       : ModulePass(ID), Out(o), UniqueNum(0), NextFunctionIndex(0), CantValidate(""), UsesSIMD(false), InvokeState(0),
-        OptLevel(OptLevel) {}
+        OptLevel(OptLevel), StackBumped(false) {}
 
     virtual const char *getPassName() const { return "JavaScript backend"; }
 
@@ -1746,7 +1747,9 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   case Instruction::Ret: {
     const ReturnInst* ret =  cast<ReturnInst>(I);
     const Value *RV = ret->getReturnValue();
-    Code << "STACKTOP = sp;";
+    if (StackBumped) {
+      Code << "STACKTOP = sp;";
+    }
     Code << "return";
     if (RV != NULL) {
       Code << " " << getValueAsCastParenStr(RV, ASM_NONSPECIFIC | ASM_MUST_CAST);
@@ -1919,6 +1922,13 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   }
   case Instruction::Alloca: {
     const AllocaInst* AI = cast<AllocaInst>(I);
+
+    // We've done an alloca, so we'll have bumped the stack and will
+    // need to restore it.
+    // Yes, we shouldn't have to bump it for nativized vars, however
+    // they are included in the frame offset, so the restore is still
+    // needed until that is fixed.
+    StackBumped = true;
 
     if (NativizedVars.count(AI)) {
       // nativized stack variable, we just need a 'var' definition
@@ -2427,6 +2437,7 @@ void JSWriter::printFunction(const Function *F) {
   nl(Out);
 
   Allocas.clear();
+  StackBumped = false;
 }
 
 void JSWriter::printModuleBody() {


### PR DESCRIPTION
Only emit stack restoration when the stack has been bumped by the
current function. This means that all functions must exercise
proper stack discipline.

This is done by looking for any static allocas during the computation
of the frame offset as well as any dynamic allocas when emitting the
code for the function.

This addresses https://github.com/kripken/emscripten/issues/3071.

cc: @chadaustin