### PR TITLE
Nativized variables shouldn't consume stack space.

### DIFF
--- a/lib/Target/JSBackend/AllocaManager.cpp
+++ b/lib/Target/JSBackend/AllocaManager.cpp
@@ -371,7 +371,7 @@ void AllocaManager::computeRepresentatives() {
   }
 }
 
-void AllocaManager::computeFrameOffsets() {
+void AllocaManager::computeFrameOffsets(const std::set<const Value*> &nativizedVars) {
   NamedRegionTimer Timer("Compute Frame Offsets", "AllocaManager",
                          TimePassesIsEnabled);
 
@@ -407,19 +407,22 @@ void AllocaManager::computeFrameOffsets() {
   for (SmallVectorImpl<AllocaInfo>::const_iterator I = SortedAllocas.begin(),
        E = SortedAllocas.end(); I != E; ++I) {
     const AllocaInfo &Info = *I;
-    uint64_t NewOffset = RoundUpToAlignment(CurrentOffset, Info.getAlignment());
+    const AllocaInst *AI = Info.getInst();
+
+    // Skip any allocas that have been nativized
+    if (nativizedVars.count(AI)) continue;
 
     // For backwards compatibility, align every power-of-two multiple alloca to
     // its greatest power-of-two factor, up to 8 bytes. In particular, cube2hash
     // is known to depend on this.
     // TODO: Consider disabling this and making people fix their code.
+    uint64_t NewOffset = RoundUpToAlignment(CurrentOffset, Info.getAlignment());
     if (uint64_t Size = Info.getSize()) {
       uint64_t P2 = uint64_t(1) << countTrailingZeros(Size);
       unsigned CompatAlign = unsigned(std::min(P2, uint64_t(8)));
       NewOffset = RoundUpToAlignment(NewOffset, CompatAlign);
     }
 
-    const AllocaInst *AI = Info.getInst();
     StaticAllocas[AI] = StaticAllocation(AI, NewOffset);
 
     CurrentOffset = NewOffset + Info.getSize();
@@ -455,7 +458,7 @@ AllocaManager::AllocaManager() : MaxAlignment(0) {
 }
 
 void AllocaManager::analyze(const Function &Func, const DataLayout &Layout,
-                            bool PerformColoring) {
+                            bool PerformColoring, const std::set<const Value*> &nativizedVars) {
   NamedRegionTimer Timer("AllocaManager", TimePassesIsEnabled);
   assert(Allocas.empty());
   assert(AllocasByIndex.empty());
@@ -495,7 +498,7 @@ void AllocaManager::analyze(const Function &Func, const DataLayout &Layout,
     }
   }
 
-  computeFrameOffsets();
+  computeFrameOffsets(nativizedVars);
   SortedAllocas.clear();
   Allocas.clear();
   AllocasByIndex.clear();

--- a/lib/Target/JSBackend/AllocaManager.h
+++ b/lib/Target/JSBackend/AllocaManager.h
@@ -26,6 +26,7 @@ class BasicBlock;
 class CallInst;
 class DataLayout;
 class Function;
+class Value;
 
 /// Compute frame layout for allocas.
 class AllocaManager {
@@ -140,7 +141,7 @@ class AllocaManager {
   void computeInterBlockLiveness();
   void computeIntraBlockLiveness();
   void computeRepresentatives();
-  void computeFrameOffsets();
+  void computeFrameOffsets(const std::set<const Value*> &nativizedVars);
 
   unsigned MaxAlignment;
 
@@ -149,7 +150,7 @@ public:
 
   /// Analyze the given function and prepare for getRepresentative queries.
   void analyze(const Function &Func, const DataLayout &Layout,
-               bool PerformColoring);
+               bool PerformColoring, const std::set<const Value*> &nativizedVars);
 
   /// Reset all stored state.
   void clear();

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -467,6 +467,7 @@ namespace {
     NativizedVarsMap NativizedVars;
 
     void calculateNativizedVars(const Function *F);
+    bool isNativizedVar(const Value*) const;
 
     // special analyses
 
@@ -647,7 +648,7 @@ const std::string &JSWriter::getJSName(const Value* val) {
 
   // If this is an alloca we've replaced with another, use the other name.
   if (const AllocaInst *AI = dyn_cast<AllocaInst>(val)) {
-    if (AI->isStaticAlloca()) {
+    if (AI->isStaticAlloca() && !isNativizedVar(AI)) {
       const AllocaInst *Rep = Allocas.getRepresentative(AI);
       if (Rep != AI) {
         return getJSName(Rep);
@@ -1951,18 +1952,15 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   case Instruction::Alloca: {
     const AllocaInst* AI = cast<AllocaInst>(I);
 
-    // We've done an alloca, so we'll have bumped the stack and will
-    // need to restore it.
-    // Yes, we shouldn't have to bump it for nativized vars, however
-    // they are included in the frame offset, so the restore is still
-    // needed until that is fixed.
-    StackBumped = true;
-
-    if (NativizedVars.count(AI)) {
+    if (isNativizedVar(AI)) {
       // nativized stack variable, we just need a 'var' definition
       UsedVars[getJSName(AI)] = AI->getType()->getElementType();
       return;
     }
+
+    // We've done an alloca, so we'll have bumped the stack and will
+    // need to restore it.
+    StackBumped = true;
 
     // Fixed-size entry-block allocations are allocated all at once in the
     // function prologue.
@@ -2003,7 +2001,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
     const LoadInst *LI = cast<LoadInst>(I);
     const Value *P = LI->getPointerOperand();
     unsigned Alignment = LI->getAlignment();
-    if (NativizedVars.count(P)) {
+    if (isNativizedVar(P)) {
       Code << getAssign(LI) << getValueAsStr(P);
     } else {
       Code << getLoad(LI, P, LI->getType(), Alignment);
@@ -2016,7 +2014,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
     const Value *V = SI->getValueOperand();
     unsigned Alignment = SI->getAlignment();
     std::string VS = getValueAsStr(V);
-    if (NativizedVars.count(P)) {
+    if (isNativizedVar(P)) {
       Code << getValueAsStr(P) << " = " << VS;
     } else {
       Code << getStore(SI, P, V->getType(), VS, Alignment);
@@ -2440,7 +2438,7 @@ void JSWriter::printFunction(const Function *F) {
     calculateNativizedVars(F);
 
   // Do alloca coloring at -O1 and higher.
-  Allocas.analyze(*F, *DL, OptLevel != CodeGenOpt::None);
+  Allocas.analyze(*F, *DL, OptLevel != CodeGenOpt::None, NativizedVars);
 
   // Emit the function
 
@@ -2887,6 +2885,10 @@ void JSWriter::calculateNativizedVars(const Function *F) {
       }
     }
   }
+}
+
+bool JSWriter::isNativizedVar(const Value *AI) const {
+  return NativizedVars.count(AI) > 0;
 }
 
 // special analyses


### PR DESCRIPTION
Prior to this change, whether or not a variable had been "nativized"
wasn't taken into account when calculating the static space required
for the frame.

Now, they aren't included in that and a minor safety measure is taken
to ensure that the frame offset of a nativized variable isn't requested.

Additionally, the logic for skipping a stack restoration no longer
emits a stack restore when only nativized variables are present within
the frame.