### PR TITLE
Pthreads

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -588,13 +588,13 @@ DEF_CALL_HANDLER(emscripten_atomic_load_u32, {
 DEF_CALL_HANDLER(emscripten_atomic_load_f32, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131613 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "__Atomics_load_f32_emulated(" + getAddressAsString(CI->getOperand(0), 2) + ")";
+  return getAssign(CI) + (PreciseF32 ? "Math_fround(" : "+") + "__Atomics_load_f32_emulated(" + getAddressAsString(CI->getOperand(0), 2) + (PreciseF32 ? "))" : ")");
 //  return getAssign(CI) + "Atomics_load(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_f64, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "__Atomics_load_f64_emulated(" + getAddressAsString(CI->getOperand(0), 3) + ")";
+  return getAssign(CI) + "+__Atomics_load_f64_emulated(" + getAddressAsString(CI->getOperand(0), 3) + ")";
 //  return getAssign(CI) + "Atomics_load(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ")";
 })
 

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -318,7 +318,7 @@ DEF_CALL_HANDLER(llvm_nacl_atomic_store_i32, {
 DEF_CALL_HANDLER(name, { \
   const Value *P = CI->getOperand(0); \
   if (EnablePthreads) { \
-    return getAssign(CI) + "Atomics_compareExchange(" HeapName ", " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")"; \
+    return getAssign(CI) + "Atomics_compareExchange(" HeapName ", " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")"; \
   } else { \
     return getLoad(CI, P, CI->getType(), 0) + ';' + \
              "if ((" + getCast(getJSName(CI), CI->getType()) + ") == " + getValueAsCastParenStr(CI->getOperand(1)) + ") " + \
@@ -554,31 +554,22 @@ DEF_CALL_HANDLER(emscripten_asm_const_double, {
   return getAssign(CI) + getCast(handleAsmConst(CI), Type::getDoubleTy(CI->getContext()));
 })
 
-std::string getAddressAsString(const Value *Ptr, int shift) {
-  Type *t = cast<PointerType>(Ptr->getType())->getElementType();
-  if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(Ptr)) {
-    return relocateGlobal(utostr(getGlobalAddress(GV->getName().str()) >> shift));
-  } else {
-    return getValueAsStr(Ptr) + ">>" + utostr(shift);
-  }
-}
-
 /* TODO: Uncomment once https://bugzilla.mozilla.org/show_bug.cgi?id=1141986 is implemented!
 
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u8, {
   return getAssign(CI) + "Atomics_exchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u16, {
-  return getAssign(CI) + "Atomics_exchange(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u32, {
-  return getAssign(CI) + "Atomics_exchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_f32, {
-  return getAssign(CI) + "Atomics_exchange(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAPF32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_f64, {
-  return getAssign(CI) + "Atomics_exchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAPF64, " + getShiftedPtr(CI->getOperand(0), 8) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 */
 
@@ -586,120 +577,120 @@ DEF_CALL_HANDLER(emscripten_atomic_cas_u8, {
   return getAssign(CI) + "Atomics_compareExchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_cas_u16, {
-  return getAssign(CI) + "Atomics_compareExchange(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+  return getAssign(CI) + "Atomics_compareExchange(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_cas_u32, {
-  return getAssign(CI) + "Atomics_compareExchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+  return getAssign(CI) + "Atomics_compareExchange(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_load_u8, {
   return getAssign(CI) + "Atomics_load(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_u16, {
-  return getAssign(CI) + "Atomics_load(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ")";
+  return getAssign(CI) + "Atomics_load(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_u32, {
-  return getAssign(CI) + "Atomics_load(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ")";
+  return getAssign(CI) + "Atomics_load(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_f32, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131613 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + (PreciseF32 ? "Math_fround(" : "+") + "__Atomics_load_f32_emulated(" + getAddressAsString(CI->getOperand(0), 2) + (PreciseF32 ? "))" : ")");
-//  return getAssign(CI) + "Atomics_load(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ")";
+  return getAssign(CI) + (PreciseF32 ? "Math_fround(" : "+") + "__Atomics_load_f32_emulated(" + getShiftedPtr(CI->getOperand(0), 4) + (PreciseF32 ? "))" : ")");
+//  return getAssign(CI) + "Atomics_load(HEAPF32, " + getShiftedPtr(CI->getOperand(0), 4) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_f64, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "+_emscripten_atomic_load_f64(" + getAddressAsString(CI->getOperand(0), 3) + ")";
-//  return getAssign(CI) + "Atomics_load(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ")";
+  return getAssign(CI) + "+_emscripten_atomic_load_f64(" + getShiftedPtr(CI->getOperand(0), 8) + ")";
+//  return getAssign(CI) + "Atomics_load(HEAPF64, " + getShiftedPtr(CI->getOperand(0), 8) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_store_u8, {
   return getAssign(CI) + "Atomics_store(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_u16, {
-  return getAssign(CI) + "Atomics_store(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_store(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_u32, {
-  return getAssign(CI) + "Atomics_store(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_store(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_f32, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131613 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "_emscripten_atomic_store_f32(" + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
-//  return getAssign(CI) + "Atomics_store(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "_emscripten_atomic_store_f32(" + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+//  return getAssign(CI) + "Atomics_store(HEAPF32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_f64, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "+_emscripten_atomic_store_f64(" + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
-//  return getAssign(CI) + "Atomics_store(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "+_emscripten_atomic_store_f64(" + getShiftedPtr(CI->getOperand(0), 8) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+//  return getAssign(CI) + "Atomics_store(HEAPF64, " + getShiftedPtr(CI->getOperand(0), 8) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_add_u8, {
   return getAssign(CI) + "Atomics_add(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_add_u16, {
-  return getAssign(CI) + "Atomics_add(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_add(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_add_u32, {
-  return getAssign(CI) + "Atomics_add(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_add(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_add_f32, {
   errs() << "emcc: warning: float32 atomic add is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
-  return getAssign(CI) + "Atomics_add(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_add(HEAPF32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_add_f64, {
   errs() << "emcc: warning: float64 atomic add is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
-  return getAssign(CI) + "Atomics_add(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_add(HEAPF64, " + getShiftedPtr(CI->getOperand(0), 8) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_sub_u8, {
   return getAssign(CI) + "Atomics_sub(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_sub_u16, {
-  return getAssign(CI) + "Atomics_sub(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_sub(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_sub_u32, {
-  return getAssign(CI) + "Atomics_sub(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_sub(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_sub_f32, {
   errs() << "emcc: warning: float32 atomic sub is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
-  return getAssign(CI) + "Atomics_sub(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_sub(HEAPF32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_sub_f64, {
   errs() << "emcc: warning: float64 atomic sub is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
-  return getAssign(CI) + "Atomics_sub(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_sub(HEAPF64, " + getShiftedPtr(CI->getOperand(0), 8) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_and_u8, {
   return getAssign(CI) + "Atomics_and(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_and_u16, {
-  return getAssign(CI) + "Atomics_and(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_and(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_and_u32, {
-  return getAssign(CI) + "Atomics_and(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_and(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_or_u8, {
   return getAssign(CI) + "Atomics_or(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_or_u16, {
-  return getAssign(CI) + "Atomics_or(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_or(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_or_u32, {
-  return getAssign(CI) + "Atomics_or(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_or(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_xor_u8, {
   return getAssign(CI) + "Atomics_xor(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_xor_u16, {
-  return getAssign(CI) + "Atomics_xor(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_xor(HEAP16, " + getShiftedPtr(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_xor_u32, {
-  return getAssign(CI) + "Atomics_xor(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "Atomics_xor(HEAP32, " + getShiftedPtr(CI->getOperand(0), 4) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 #define DEF_BUILTIN_HANDLER(name, to) \

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -558,6 +558,22 @@ std::string getAddressAsString(const Value *Ptr, int shift) {
   }
 }
 
+DEF_CALL_HANDLER(emscripten_atomic_exchange_u8, {
+  return getAssign(CI) + "Atomics_exchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_exchange_u16, {
+  return getAssign(CI) + "Atomics_exchange(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_exchange_u32, {
+  return getAssign(CI) + "Atomics_exchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_exchange_f32, {
+  return getAssign(CI) + "Atomics_exchange(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_exchange_f64, {
+  return getAssign(CI) + "Atomics_exchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+
 DEF_CALL_HANDLER(emscripten_atomic_cas_u8, {
   return getAssign(CI) + "Atomics_compareExchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
@@ -864,6 +880,12 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(emscripten_asm_const);
   SETUP_CALL_HANDLER(emscripten_asm_const_int);
   SETUP_CALL_HANDLER(emscripten_asm_const_double);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_exchange_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_exchange_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_exchange_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_exchange_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_exchange_f64);
 
   SETUP_CALL_HANDLER(emscripten_atomic_cas_u8);
   SETUP_CALL_HANDLER(emscripten_atomic_cas_u16);

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -558,6 +558,8 @@ std::string getAddressAsString(const Value *Ptr, int shift) {
   }
 }
 
+/* TODO: Uncomment once https://bugzilla.mozilla.org/show_bug.cgi?id=1141986 is implemented!
+
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u8, {
   return getAssign(CI) + "Atomics_exchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
@@ -573,6 +575,7 @@ DEF_CALL_HANDLER(emscripten_atomic_exchange_f32, {
 DEF_CALL_HANDLER(emscripten_atomic_exchange_f64, {
   return getAssign(CI) + "Atomics_exchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
+*/
 
 DEF_CALL_HANDLER(emscripten_atomic_cas_u8, {
   return getAssign(CI) + "Atomics_compareExchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
@@ -881,11 +884,13 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(emscripten_asm_const_int);
   SETUP_CALL_HANDLER(emscripten_asm_const_double);
 
+/* TODO: Uncomment once https://bugzilla.mozilla.org/show_bug.cgi?id=1141986 is implemented!
   SETUP_CALL_HANDLER(emscripten_atomic_exchange_u8);
   SETUP_CALL_HANDLER(emscripten_atomic_exchange_u16);
   SETUP_CALL_HANDLER(emscripten_atomic_exchange_u32);
   SETUP_CALL_HANDLER(emscripten_atomic_exchange_f32);
   SETUP_CALL_HANDLER(emscripten_atomic_exchange_f64);
+*/
 
   SETUP_CALL_HANDLER(emscripten_atomic_cas_u8);
   SETUP_CALL_HANDLER(emscripten_atomic_cas_u16);

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -561,21 +561,129 @@ std::string getAddressAsString(const Value *Ptr, int shift) {
 DEF_CALL_HANDLER(emscripten_atomic_cas_u8, {
   return getAssign(CI) + "Atomics_compareExchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
-
 DEF_CALL_HANDLER(emscripten_atomic_cas_u16, {
   return getAssign(CI) + "Atomics_compareExchange(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
-
 DEF_CALL_HANDLER(emscripten_atomic_cas_u32, {
   return getAssign(CI) + "Atomics_compareExchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
-
 DEF_CALL_HANDLER(emscripten_atomic_cas_f32, {
   return getAssign(CI) + "Atomics_compareExchange(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
-
 DEF_CALL_HANDLER(emscripten_atomic_cas_f64, {
   return getAssign(CI) + "Atomics_compareExchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_load_u8, {
+  return getAssign(CI) + "Atomics_load(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_load_u16, {
+  return getAssign(CI) + "Atomics_load(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_load_u32, {
+  return getAssign(CI) + "Atomics_load(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_load_f32, {
+  return getAssign(CI) + "Atomics_load(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_load_f64, {
+  return getAssign(CI) + "Atomics_load(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_store_u8, {
+  return getAssign(CI) + "Atomics_store(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_store_u16, {
+  return getAssign(CI) + "Atomics_store(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_store_u32, {
+  return getAssign(CI) + "Atomics_store(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_store_f32, {
+  return getAssign(CI) + "Atomics_store(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_store_f64, {
+  return getAssign(CI) + "Atomics_store(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_add_u8, {
+  return getAssign(CI) + "Atomics_add(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_add_u16, {
+  return getAssign(CI) + "Atomics_add(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_add_u32, {
+  return getAssign(CI) + "Atomics_add(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_add_f32, {
+  return getAssign(CI) + "Atomics_add(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_add_f64, {
+  return getAssign(CI) + "Atomics_add(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_sub_u8, {
+  return getAssign(CI) + "Atomics_sub(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_sub_u16, {
+  return getAssign(CI) + "Atomics_sub(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_sub_u32, {
+  return getAssign(CI) + "Atomics_sub(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_sub_f32, {
+  return getAssign(CI) + "Atomics_sub(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_sub_f64, {
+  return getAssign(CI) + "Atomics_sub(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_and_u8, {
+  return getAssign(CI) + "Atomics_and(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_and_u16, {
+  return getAssign(CI) + "Atomics_and(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_and_u32, {
+  return getAssign(CI) + "Atomics_and(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_and_f32, {
+  return getAssign(CI) + "Atomics_and(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_and_f64, {
+  return getAssign(CI) + "Atomics_and(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_or_u8, {
+  return getAssign(CI) + "Atomics_or(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_or_u16, {
+  return getAssign(CI) + "Atomics_or(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_or_u32, {
+  return getAssign(CI) + "Atomics_or(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_or_f32, {
+  return getAssign(CI) + "Atomics_or(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_or_f64, {
+  return getAssign(CI) + "Atomics_or(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_xor_u8, {
+  return getAssign(CI) + "Atomics_xor(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_xor_u16, {
+  return getAssign(CI) + "Atomics_xor(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_xor_u32, {
+  return getAssign(CI) + "Atomics_xor(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_xor_f32, {
+  return getAssign(CI) + "Atomics_xor(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+})
+DEF_CALL_HANDLER(emscripten_atomic_xor_f64, {
+  return getAssign(CI) + "Atomics_xor(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 #define DEF_BUILTIN_HANDLER(name, to) \
@@ -666,6 +774,7 @@ DEF_BUILTIN_HANDLER(emscripten_int32x4_greaterThanOrEqual, SIMD_int32x4_greaterT
 DEF_BUILTIN_HANDLER(emscripten_int32x4_select, SIMD_int32x4_select);
 DEF_BUILTIN_HANDLER(emscripten_int32x4_fromFloat32x4Bits, SIMD_int32x4_fromFloat32x4Bits);
 DEF_BUILTIN_HANDLER(emscripten_int32x4_fromFloat32x4, SIMD_int32x4_fromFloat32x4);
+DEF_BUILTIN_HANDLER(emscripten_atomic_fence, Atomics_fence);
 
 // Setups
 
@@ -761,6 +870,50 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(emscripten_atomic_cas_u32);
   SETUP_CALL_HANDLER(emscripten_atomic_cas_f32);
   SETUP_CALL_HANDLER(emscripten_atomic_cas_f64);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_load_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_load_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_load_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_load_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_load_f64);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_store_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_store_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_store_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_store_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_store_f64);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_add_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_add_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_add_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_add_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_add_f64);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_sub_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_sub_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_sub_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_sub_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_sub_f64);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_and_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_and_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_and_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_and_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_and_f64);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_or_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_or_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_or_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_or_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_or_f64);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_xor_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_xor_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_xor_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_xor_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_xor_f64);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_fence);
 
   SETUP_CALL_HANDLER(abs);
   SETUP_CALL_HANDLER(labs);

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -552,7 +552,7 @@ DEF_CALL_HANDLER(emscripten_asm_const_double, {
 std::string getAddressAsString(const Value *Ptr, int shift) {
   Type *t = cast<PointerType>(Ptr->getType())->getElementType();
   if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(Ptr)) {
-    return utostr(getGlobalAddress(GV->getName().str()) >> shift);
+    return relocateGlobal(utostr(getGlobalAddress(GV->getName().str()) >> shift));
   } else {
     return getValueAsStr(Ptr) + ">>" + utostr(shift);
   }
@@ -585,14 +585,6 @@ DEF_CALL_HANDLER(emscripten_atomic_cas_u16, {
 })
 DEF_CALL_HANDLER(emscripten_atomic_cas_u32, {
   return getAssign(CI) + "Atomics_compareExchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
-})
-DEF_CALL_HANDLER(emscripten_atomic_cas_f32, {
-  errs() << "emcc: warning: float32 compare-and-swap is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
-  return getAssign(CI) + "Atomics_compareExchange(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
-})
-DEF_CALL_HANDLER(emscripten_atomic_cas_f64, {
-  errs() << "emcc: warning: float64 compare-and-swap is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
-  return getAssign(CI) + "Atomics_compareExchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_load_u8, {
@@ -895,8 +887,6 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(emscripten_atomic_cas_u8);
   SETUP_CALL_HANDLER(emscripten_atomic_cas_u16);
   SETUP_CALL_HANDLER(emscripten_atomic_cas_u32);
-  SETUP_CALL_HANDLER(emscripten_atomic_cas_f32);
-  SETUP_CALL_HANDLER(emscripten_atomic_cas_f64);
 
   SETUP_CALL_HANDLER(emscripten_atomic_load_u8);
   SETUP_CALL_HANDLER(emscripten_atomic_load_u16);

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -559,19 +559,19 @@ std::string getAddressAsString(const Value *Ptr, int shift) {
 }
 
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u8, {
-  return getAssign(CI) + "Atomics_exchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u16, {
-  return getAssign(CI) + "Atomics_exchange(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_u32, {
-  return getAssign(CI) + "Atomics_exchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_f32, {
-  return getAssign(CI) + "Atomics_exchange(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_exchange_f64, {
-  return getAssign(CI) + "Atomics_exchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+  return getAssign(CI) + "Atomics_exchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_cas_u8, {

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -568,9 +568,11 @@ DEF_CALL_HANDLER(emscripten_atomic_cas_u32, {
   return getAssign(CI) + "Atomics_compareExchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_cas_f32, {
+  errs() << "emcc: warning: float32 compare-and-swap is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
   return getAssign(CI) + "Atomics_compareExchange(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_cas_f64, {
+  errs() << "emcc: warning: float64 compare-and-swap is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
   return getAssign(CI) + "Atomics_compareExchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
 })
 
@@ -584,10 +586,16 @@ DEF_CALL_HANDLER(emscripten_atomic_load_u32, {
   return getAssign(CI) + "Atomics_load(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_f32, {
-  return getAssign(CI) + "Atomics_load(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ")";
+  // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131613 is implemented, we could use the commented out version. Until then,
+  // we must emulate manually.
+  return getAssign(CI) + "__Atomics_load_f32_emulated(" + getAddressAsString(CI->getOperand(0), 2) + ")";
+//  return getAssign(CI) + "Atomics_load(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_load_f64, {
-  return getAssign(CI) + "Atomics_load(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ")";
+  // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
+  // we must emulate manually.
+  return getAssign(CI) + "__Atomics_load_f64_emulated(" + getAddressAsString(CI->getOperand(0), 3) + ")";
+//  return getAssign(CI) + "Atomics_load(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_store_u8, {
@@ -600,10 +608,16 @@ DEF_CALL_HANDLER(emscripten_atomic_store_u32, {
   return getAssign(CI) + "Atomics_store(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_f32, {
-  return getAssign(CI) + "Atomics_store(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131613 is implemented, we could use the commented out version. Until then,
+  // we must emulate manually.
+  return getAssign(CI) + "__Atomics_store_f32_emulated(" + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+//  return getAssign(CI) + "Atomics_store(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_f64, {
-  return getAssign(CI) + "Atomics_store(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
+  // we must emulate manually.
+  return getAssign(CI) + "__Atomics_store_f64_emulated(" + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+//  return getAssign(CI) + "Atomics_store(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 DEF_CALL_HANDLER(emscripten_atomic_add_u8, {
@@ -616,9 +630,11 @@ DEF_CALL_HANDLER(emscripten_atomic_add_u32, {
   return getAssign(CI) + "Atomics_add(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_add_f32, {
+  errs() << "emcc: warning: float32 atomic add is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
   return getAssign(CI) + "Atomics_add(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_add_f64, {
+  errs() << "emcc: warning: float64 atomic add is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
   return getAssign(CI) + "Atomics_add(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
@@ -632,9 +648,11 @@ DEF_CALL_HANDLER(emscripten_atomic_sub_u32, {
   return getAssign(CI) + "Atomics_sub(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_sub_f32, {
+  errs() << "emcc: warning: float32 atomic sub is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
   return getAssign(CI) + "Atomics_sub(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_sub_f64, {
+  errs() << "emcc: warning: float64 atomic sub is not supported!" << CI->getParent()->getParent()->getName() << ":" << *CI << "\n";
   return getAssign(CI) + "Atomics_sub(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
@@ -647,12 +665,6 @@ DEF_CALL_HANDLER(emscripten_atomic_and_u16, {
 DEF_CALL_HANDLER(emscripten_atomic_and_u32, {
   return getAssign(CI) + "Atomics_and(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
-DEF_CALL_HANDLER(emscripten_atomic_and_f32, {
-  return getAssign(CI) + "Atomics_and(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
-})
-DEF_CALL_HANDLER(emscripten_atomic_and_f64, {
-  return getAssign(CI) + "Atomics_and(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
-})
 
 DEF_CALL_HANDLER(emscripten_atomic_or_u8, {
   return getAssign(CI) + "Atomics_or(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
@@ -663,12 +675,6 @@ DEF_CALL_HANDLER(emscripten_atomic_or_u16, {
 DEF_CALL_HANDLER(emscripten_atomic_or_u32, {
   return getAssign(CI) + "Atomics_or(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
-DEF_CALL_HANDLER(emscripten_atomic_or_f32, {
-  return getAssign(CI) + "Atomics_or(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
-})
-DEF_CALL_HANDLER(emscripten_atomic_or_f64, {
-  return getAssign(CI) + "Atomics_or(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
-})
 
 DEF_CALL_HANDLER(emscripten_atomic_xor_u8, {
   return getAssign(CI) + "Atomics_xor(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
@@ -678,12 +684,6 @@ DEF_CALL_HANDLER(emscripten_atomic_xor_u16, {
 })
 DEF_CALL_HANDLER(emscripten_atomic_xor_u32, {
   return getAssign(CI) + "Atomics_xor(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
-})
-DEF_CALL_HANDLER(emscripten_atomic_xor_f32, {
-  return getAssign(CI) + "Atomics_xor(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
-})
-DEF_CALL_HANDLER(emscripten_atomic_xor_f64, {
-  return getAssign(CI) + "Atomics_xor(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 
 #define DEF_BUILTIN_HANDLER(name, to) \
@@ -898,20 +898,14 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(emscripten_atomic_and_u8);
   SETUP_CALL_HANDLER(emscripten_atomic_and_u16);
   SETUP_CALL_HANDLER(emscripten_atomic_and_u32);
-  SETUP_CALL_HANDLER(emscripten_atomic_and_f32);
-  SETUP_CALL_HANDLER(emscripten_atomic_and_f64);
 
   SETUP_CALL_HANDLER(emscripten_atomic_or_u8);
   SETUP_CALL_HANDLER(emscripten_atomic_or_u16);
   SETUP_CALL_HANDLER(emscripten_atomic_or_u32);
-  SETUP_CALL_HANDLER(emscripten_atomic_or_f32);
-  SETUP_CALL_HANDLER(emscripten_atomic_or_f64);
 
   SETUP_CALL_HANDLER(emscripten_atomic_xor_u8);
   SETUP_CALL_HANDLER(emscripten_atomic_xor_u16);
   SETUP_CALL_HANDLER(emscripten_atomic_xor_u32);
-  SETUP_CALL_HANDLER(emscripten_atomic_xor_f32);
-  SETUP_CALL_HANDLER(emscripten_atomic_xor_f64);
 
   SETUP_CALL_HANDLER(emscripten_atomic_fence);
 

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -616,7 +616,7 @@ DEF_CALL_HANDLER(emscripten_atomic_store_f32, {
 DEF_CALL_HANDLER(emscripten_atomic_store_f64, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "_emscripten_atomic_store_f64(" + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "+_emscripten_atomic_store_f64(" + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 //  return getAssign(CI) + "Atomics_store(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -549,6 +549,35 @@ DEF_CALL_HANDLER(emscripten_asm_const_double, {
   return getAssign(CI) + getCast(handleAsmConst(CI), Type::getDoubleTy(CI->getContext()));
 })
 
+std::string getAddressAsString(const Value *Ptr, int shift) {
+  Type *t = cast<PointerType>(Ptr->getType())->getElementType();
+  if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(Ptr)) {
+    return utostr(getGlobalAddress(GV->getName().str()) >> shift);
+  } else {
+    return getValueAsStr(Ptr) + ">>" + utostr(shift);
+  }
+}
+
+DEF_CALL_HANDLER(emscripten_atomic_cas_u8, {
+  return getAssign(CI) + "Atomics_compareExchange(HEAP8, " + getValueAsStr(CI->getOperand(0)) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_cas_u16, {
+  return getAssign(CI) + "Atomics_compareExchange(HEAP16, " + getAddressAsString(CI->getOperand(0), 1) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_cas_u32, {
+  return getAssign(CI) + "Atomics_compareExchange(HEAP32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_cas_f32, {
+  return getAssign(CI) + "Atomics_compareExchange(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+
+DEF_CALL_HANDLER(emscripten_atomic_cas_f64, {
+  return getAssign(CI) + "Atomics_compareExchange(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ", " + getValueAsStr(CI->getOperand(2)) + ")";
+})
+
 #define DEF_BUILTIN_HANDLER(name, to) \
 DEF_CALL_HANDLER(name, { \
   return CH___default__(CI, #to); \
@@ -726,6 +755,12 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(emscripten_asm_const);
   SETUP_CALL_HANDLER(emscripten_asm_const_int);
   SETUP_CALL_HANDLER(emscripten_asm_const_double);
+
+  SETUP_CALL_HANDLER(emscripten_atomic_cas_u8);
+  SETUP_CALL_HANDLER(emscripten_atomic_cas_u16);
+  SETUP_CALL_HANDLER(emscripten_atomic_cas_u32);
+  SETUP_CALL_HANDLER(emscripten_atomic_cas_f32);
+  SETUP_CALL_HANDLER(emscripten_atomic_cas_f64);
 
   SETUP_CALL_HANDLER(abs);
   SETUP_CALL_HANDLER(labs);

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -594,7 +594,7 @@ DEF_CALL_HANDLER(emscripten_atomic_load_f32, {
 DEF_CALL_HANDLER(emscripten_atomic_load_f64, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "+__Atomics_load_f64_emulated(" + getAddressAsString(CI->getOperand(0), 3) + ")";
+  return getAssign(CI) + "+_emscripten_atomic_load_f64(" + getAddressAsString(CI->getOperand(0), 3) + ")";
 //  return getAssign(CI) + "Atomics_load(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ")";
 })
 
@@ -610,13 +610,13 @@ DEF_CALL_HANDLER(emscripten_atomic_store_u32, {
 DEF_CALL_HANDLER(emscripten_atomic_store_f32, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131613 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "__Atomics_store_f32_emulated(" + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "_emscripten_atomic_store_f32(" + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 //  return getAssign(CI) + "Atomics_store(HEAPF32, " + getAddressAsString(CI->getOperand(0), 2) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 DEF_CALL_HANDLER(emscripten_atomic_store_f64, {
   // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 is implemented, we could use the commented out version. Until then,
   // we must emulate manually.
-  return getAssign(CI) + "__Atomics_store_f64_emulated(" + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
+  return getAssign(CI) + "_emscripten_atomic_store_f64(" + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 //  return getAssign(CI) + "Atomics_store(HEAPF64, " + getAddressAsString(CI->getOperand(0), 3) + ", " + getValueAsStr(CI->getOperand(1)) + ")";
 })
 

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2394,7 +2394,11 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
     break;
   }
   case Instruction::Fence: // no threads, so nothing to do here
-    Code << "/* fence */";
+    if (true/*compilingWithPthreadsSupport*/) {
+      Code << "Atomics.fence()";
+    } else {
+      Code << "/* fence */";
+    }
     break;
   }
 

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -885,7 +885,7 @@ std::string JSWriter::getLoad(const Instruction *I, const Value *P, Type *T, uns
     if (cast<LoadInst>(I)->isVolatile()) {
       const char *HeapName;
       std::string Index = getHeapNameAndIndex(P, &HeapName);
-      text = Assign + "Atomics.load(" + HeapName + ',' + Index + ')';
+      text = Assign + "Atomics_load(" + HeapName + ',' + Index + ')';
     } else {
       text = Assign + getPtrLoad(P);
     }
@@ -988,7 +988,7 @@ std::string JSWriter::getLoad(const Instruction *I, const Value *P, Type *T, uns
   return text;
 }
 
-static const std::string AtomicsStore = "Atomics.store(";
+static const std::string AtomicsStore = "Atomics_store(";
 
 std::string JSWriter::getStore(const Instruction *I, const Value *P, Type *T, const std::string& VS, unsigned Alignment, char sep) {
   assert(sep == ';'); // FIXME when we need that
@@ -2344,7 +2344,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
       std::string Index = getHeapNameAndIndex(P, &HeapName);
       //std::string Assign = getAssign(cxi);
       std::string Assign = getJSName(I);
-      Code << Assign << "_0 = Atomics.compareExchange(" << HeapName << ", " << Index << ", " << getValueAsStr(I->getOperand(1)) << ", " << getValueAsStr(I->getOperand(2)) << ");\n";
+      Code << Assign << "_0 = Atomics_compareExchange(" << HeapName << ", " << Index << ", " << getValueAsStr(I->getOperand(1)) << ", " << getValueAsStr(I->getOperand(2)) << ");\n";
       Code << Assign << "_1 = (" << Assign << "_0|0) == (" << getValueAsStr(I->getOperand(1)) << "|0)";
     } else {
       report_fatal_error("TODO: AtomicCmpXchg without pthreads not currently supported!");
@@ -2370,12 +2370,12 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
       std::string Index = getHeapNameAndIndex(P, &HeapName);
       const char *atomicFunc = 0;
       switch (rmwi->getOperation()) {
-        case AtomicRMWInst::Xchg: atomicFunc = "Atomics.store("; break;
-        case AtomicRMWInst::Add: atomicFunc = "Atomics.add("; break;
-        case AtomicRMWInst::Sub: atomicFunc = "Atomics.sub("; break;
-        case AtomicRMWInst::And: atomicFunc = "Atomics.and("; break;
-        case AtomicRMWInst::Or: atomicFunc = "Atomics.or("; break;
-        case AtomicRMWInst::Xor: atomicFunc = "Atomics.xor("; break;
+        case AtomicRMWInst::Xchg: atomicFunc = "Atomics_store("; break;
+        case AtomicRMWInst::Add: atomicFunc = "Atomics_add("; break;
+        case AtomicRMWInst::Sub: atomicFunc = "Atomics_sub("; break;
+        case AtomicRMWInst::And: atomicFunc = "Atomics_and("; break;
+        case AtomicRMWInst::Or: atomicFunc = "Atomics_or("; break;
+        case AtomicRMWInst::Xor: atomicFunc = "Atomics_xor("; break;
         case AtomicRMWInst::Nand: // TODO
         case AtomicRMWInst::Max:
         case AtomicRMWInst::Min:
@@ -2406,7 +2406,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   }
   case Instruction::Fence: // no threads, so nothing to do here
     if (true/*compilingWithPthreadsSupport*/) {
-      Code << "Atomics.fence()";
+      Code << "Atomics_fence()";
     } else {
       Code << "/* fence */";
     }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1030,6 +1030,10 @@ std::string JSWriter::getStore(const Instruction *I, const Value *P, Type *T, co
         // TODO: If https://bugzilla.mozilla.org/show_bug.cgi?id=1131613 and https://bugzilla.mozilla.org/show_bug.cgi?id=1131624 are
         // implemented, we could remove the emulation, but until then we must emulate manually.
         text = std::string("_emscripten_atomic_store_") + heapNameToAtomicTypeName(HeapName) + "(" + getByteAddressAsStr(P) + ',' + VS + ')';
+        if (PreciseF32 && !strcmp(HeapName, "HEAPF32"))
+          text = "Math_fround(" + text + ")";
+        else
+          text = "+" + text;
       } else {
         text = std::string("Atomics_store(") + HeapName + ',' + Index + ',' + VS + ')';
       }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2434,11 +2434,11 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
     }
     break;
   }
-  case Instruction::Fence: // no threads, so nothing to do here
+  case Instruction::Fence:
     if (EnablePthreads) {
       Code << "Atomics_fence()";
     } else {
-      Code << "/* fence */";
+      Code << "/* fence */"; // no threads, so nothing to do here
     }
     break;
   }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2367,30 +2367,6 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
                                     getValueAsStr(I->getOperand(2));
     break;
   }
-  case Instruction::ExtractValue: {
-    const ExtractValueInst *evi = cast<ExtractValueInst>(I);
-    std::string Assign = getAssign(evi);
-    Code << Assign << getValueAsStr(I->getOperand(0)) << "_" << evi->idx_begin()[0];
-    break;
-  }
-  case Instruction::AtomicCmpXchg: {
-    const AtomicCmpXchgInst *cxi = cast<AtomicCmpXchgInst>(I);
-    const Value *P = I->getOperand(0);
-    const char *HeapName;
-    std::string Index = getHeapNameAndIndex(P, &HeapName);
-    std::string Assign = getJSName(I);
-    UsedVars[Assign + "_0"] = I->getOperand(1)->getType();
-    UsedVars[Assign + "_1"] = Type::getInt1Ty(P->getContext());
-    if (EnablePthreads) {
-      Code << Assign << "_0 = Atomics_compareExchange(" << HeapName << ", " << Index << ", " << getValueAsStr(I->getOperand(1)) << ", " << getValueAsStr(I->getOperand(2)) << ");\n";
-      Code << Assign << "_1 = (" << Assign << "_0|0) == (" << getValueAsStr(I->getOperand(1)) << "|0)";
-    } else {
-      Code << Assign << "_0 = " << HeapName << "[" << Index << "];\n";
-      Code << Assign << "_1 = (" << Assign << "_0|0) == (" << getValueAsStr(I->getOperand(1)) << "|0); ";
-      Code << "if (" << Assign << "_1) " << getStore(cxi, P, I->getType(), getValueAsStr(I->getOperand(2)), 0);
-    }
-    break;
-  }
   case Instruction::AtomicRMW: {
     const AtomicRMWInst *rmwi = cast<AtomicRMWInst>(I);
     const Value *P = rmwi->getOperand(0);

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1010,8 +1010,6 @@ std::string JSWriter::getLoad(const Instruction *I, const Value *P, Type *T, uns
   return text;
 }
 
-static const std::string AtomicsStore = "Atomics_store(";
-
 std::string JSWriter::getStore(const Instruction *I, const Value *P, Type *T, const std::string& VS, unsigned Alignment, char sep) {
   assert(sep == ';'); // FIXME when we need that
   unsigned Bytes = DL->getTypeAllocSize(T);
@@ -1025,7 +1023,7 @@ std::string JSWriter::getStore(const Instruction *I, const Value *P, Type *T, co
         // implemented, we could remove the emulation, but until then we must emulate manually.
         text = std::string("__Atomics_store_") + HeapName + "_emulated(" + getByteAddressAsStr(P) + ',' + VS + ')';
       } else {
-        text = AtomicsStore + HeapName + ',' + Index + ',' + VS + ')';
+        text = std::string("Atomics_store(") + HeapName + ',' + Index + ',' + VS + ')';
       }
     } else {
       text = getPtrUse(P) + " = " + VS;

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2395,11 +2395,11 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
       const char *atomicFunc = 0;
       switch (rmwi->getOperation()) {
         case AtomicRMWInst::Xchg: atomicFunc = "Atomics_store"; break;
-        case AtomicRMWInst::Add: atomicFunc = "Atomics_add"; break;
-        case AtomicRMWInst::Sub: atomicFunc = "Atomics_sub"; break;
-        case AtomicRMWInst::And: atomicFunc = "Atomics_and"; break;
-        case AtomicRMWInst::Or: atomicFunc = "Atomics_or"; break;
-        case AtomicRMWInst::Xor: atomicFunc = "Atomics_xor"; break;
+        case AtomicRMWInst::Add:  atomicFunc = "Atomics_add"; break;
+        case AtomicRMWInst::Sub:  atomicFunc = "Atomics_sub"; break;
+        case AtomicRMWInst::And:  atomicFunc = "Atomics_and"; break;
+        case AtomicRMWInst::Or:   atomicFunc = "Atomics_or"; break;
+        case AtomicRMWInst::Xor:  atomicFunc = "Atomics_xor"; break;
         case AtomicRMWInst::Nand: // TODO
         case AtomicRMWInst::Max:
         case AtomicRMWInst::Min:
@@ -2419,7 +2419,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
       // Most bitcasts are no-ops for us. However, the exception is int to float and float to int
       switch (rmwi->getOperation()) {
         case AtomicRMWInst::Xchg: Code << getStore(rmwi, P, I->getType(), VS, 0); break;
-        case AtomicRMWInst::Add: Code << getStore(rmwi, P, I->getType(), "((" + getJSName(I) + '+' + VS + ")|0)", 0); break;
+        case AtomicRMWInst::Add:  Code << getStore(rmwi, P, I->getType(), "((" + getJSName(I) + '+' + VS + ")|0)", 0); break;
         case AtomicRMWInst::Sub:  Code << getStore(rmwi, P, I->getType(), "((" + getJSName(I) + '-' + VS + ")|0)", 0); break;
         case AtomicRMWInst::And:  Code << getStore(rmwi, P, I->getType(), "(" + getJSName(I) + '&' + VS + ")", 0); break;
         case AtomicRMWInst::Nand: Code << getStore(rmwi, P, I->getType(), "(~(" + getJSName(I) + '&' + VS + "))", 0); break;

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -898,7 +898,7 @@ std::string JSWriter::getLoad(const Instruction *I, const Value *P, Type *T, uns
   unsigned Bytes = DL->getTypeAllocSize(T);
   std::string text;
   if (Bytes <= Alignment || Alignment == 0) {
-    if (cast<LoadInst>(I)->isVolatile()) {
+    if (EnablePthreads && cast<LoadInst>(I)->isVolatile()) {
       const char *HeapName;
       std::string Index = getHeapNameAndIndex(P, &HeapName);
       if (!strcmp(HeapName, "HEAPF32") || !strcmp(HeapName, "HEAPF64")) {

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2368,13 +2368,15 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
     const char *HeapName;
     std::string Index = getHeapNameAndIndex(P, &HeapName);
     std::string Assign = getJSName(I);
+    UsedVars[Assign + "_0"] = I->getOperand(1)->getType();
+    UsedVars[Assign + "_1"] = Type::getInt1Ty(P->getContext());
     if (EnablePthreads) {
       Code << Assign << "_0 = Atomics_compareExchange(" << HeapName << ", " << Index << ", " << getValueAsStr(I->getOperand(1)) << ", " << getValueAsStr(I->getOperand(2)) << ");\n";
       Code << Assign << "_1 = (" << Assign << "_0|0) == (" << getValueAsStr(I->getOperand(1)) << "|0)";
     } else {
       Code << Assign << "_0 = " << HeapName << "[" << Index << "];\n";
       Code << Assign << "_1 = (" << Assign << "_0|0) == (" << getValueAsStr(I->getOperand(1)) << "|0); ";
-	  Code << "if (" << Assign << "_1) " << getStore(cxi, P, I->getType(), getValueAsStr(I->getOperand(2)), 0);
+      Code << "if (" << Assign << "_1) " << getStore(cxi, P, I->getType(), getValueAsStr(I->getOperand(2)), 0);
     }
     break;
   }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2799,9 +2799,11 @@ void JSWriter::printModuleBody() {
 
   assert(GlobalData32.size() == 0 && GlobalData8.size() == 0); // FIXME when we use optimal constant alignments
 
-  // TODO fix commas
-  Out << "if (!ENVIRONMENT_IS_PTHREAD) {\n";
+  if (EnablePthreads) {
+    Out << "if (!ENVIRONMENT_IS_PTHREAD) {\n";
+  }
   Out << "/* memory initializer */ allocate([";
+  // TODO fix commas
   printCommaSeparated(GlobalData64);
   if (GlobalData64.size() > 0 && GlobalData32.size() + GlobalData8.size() > 0) {
     Out << ",";
@@ -2812,7 +2814,9 @@ void JSWriter::printModuleBody() {
   }
   printCommaSeparated(GlobalData8);
   Out << "], \"i8\", ALLOC_NONE, Runtime.GLOBAL_BASE);\n";
-  Out << "}\n";
+  if (EnablePthreads) {
+    Out << "}\n";
+  }
 
   // Emit metadata for emcc driver
   Out << "\n\n// EMSCRIPTEN_METADATA\n";

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2406,7 +2406,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
       std::string Index = getHeapNameAndIndex(P, &HeapName);
       const char *atomicFunc = 0;
       switch (rmwi->getOperation()) {
-        case AtomicRMWInst::Xchg: atomicFunc = "store"; break;
+        case AtomicRMWInst::Xchg: atomicFunc = "exchange"; break;
         case AtomicRMWInst::Add:  atomicFunc = "add"; break;
         case AtomicRMWInst::Sub:  atomicFunc = "sub"; break;
         case AtomicRMWInst::And:  atomicFunc = "and"; break;

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2424,6 +2424,11 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
         // implemented, we could remove the emulation, but until then we must emulate manually.
         bool fround = PreciseF32 && !strcmp(HeapName, "HEAPF32");
         Code << Assign << (fround ? "Math_fround(" : "+") << "_emscripten_atomic_" << atomicFunc << "_" << heapNameToAtomicTypeName(HeapName) << "(" << getByteAddressAsStr(P) << ", " << VS << (fround ? "))" : ")"); break;
+
+      // TODO: Remove the following two lines once https://bugzilla.mozilla.org/show_bug.cgi?id=1141986 is implemented!
+      } else if (rmwi->getOperation() == AtomicRMWInst::Xchg && !strcmp(HeapName, "HEAP32")) {
+        Code << Assign << "_emscripten_atomic_exchange_u32(" << getByteAddressAsStr(P) << ", " << VS << ")|0"; break;
+
       } else {
         Code << Assign << "Atomics_" << atomicFunc << "(" << HeapName << ", " << Index << ", " << VS << ")"; break;
       }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2650,6 +2650,7 @@ void JSWriter::printModuleBody() {
   assert(GlobalData32.size() == 0 && GlobalData8.size() == 0); // FIXME when we use optimal constant alignments
 
   // TODO fix commas
+  Out << "if (!ENVIRONMENT_IS_PTHREAD) {\n";
   Out << "/* memory initializer */ allocate([";
   printCommaSeparated(GlobalData64);
   if (GlobalData64.size() > 0 && GlobalData32.size() + GlobalData8.size() > 0) {
@@ -2660,7 +2661,8 @@ void JSWriter::printModuleBody() {
     Out << ",";
   }
   printCommaSeparated(GlobalData8);
-  Out << "], \"i8\", ALLOC_NONE, Runtime.GLOBAL_BASE);";
+  Out << "], \"i8\", ALLOC_NONE, Runtime.GLOBAL_BASE);\n";
+  Out << "}\n";
 
   // Emit metadata for emcc driver
   Out << "\n\n// EMSCRIPTEN_METADATA\n";

--- a/lib/Transforms/NaCl/RewriteAtomics.cpp
+++ b/lib/Transforms/NaCl/RewriteAtomics.cpp
@@ -379,6 +379,7 @@ void AtomicVisitor::visitAtomicRMWInst(AtomicRMWInst &I) {
 ///   %success = icmp eq %old, %val
 /// Note: weak is currently dropped if present, the cmpxchg is always strong.
 void AtomicVisitor::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
+  return; // XXX EMSCRIPTEN
   PointerHelper<AtomicCmpXchgInst> PH(*this, I);
   const NaCl::AtomicIntrinsics::AtomicIntrinsic *Intrinsic =
       findAtomicIntrinsic(I, Intrinsic::nacl_atomic_cmpxchg, PH.PET);

--- a/lib/Transforms/NaCl/RewriteAtomics.cpp
+++ b/lib/Transforms/NaCl/RewriteAtomics.cpp
@@ -379,7 +379,6 @@ void AtomicVisitor::visitAtomicRMWInst(AtomicRMWInst &I) {
 ///   %success = icmp eq %old, %val
 /// Note: weak is currently dropped if present, the cmpxchg is always strong.
 void AtomicVisitor::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
-  return; // XXX EMSCRIPTEN
   PointerHelper<AtomicCmpXchgInst> PH(*this, I);
   const NaCl::AtomicIntrinsics::AtomicIntrinsic *Intrinsic =
       findAtomicIntrinsic(I, Intrinsic::nacl_atomic_cmpxchg, PH.PET);


### PR DESCRIPTION
Adds LLVM side support for compiling for the pthreads/atomics support.

This set of commits implements initial pthreads library support for Emscripten code, and allows native code to utilize multithreading with the pthreads API. This backs on experimental research on the JavaScript SharedArrayBuffer and Atomics APIs from https://docs.google.com/document/d/1NDGA_gZJ7M7w1Bh8S0AoDyEqwDdRh4uSoTPSNn77PFk/edit?usp=sharing , and as such is preliminary and unsupported in other browsers except current Firefox Nightly builds. By default pthreads support is disabled, and the feature must be explicitly enabled by specifying the compiler flag -s USE_PTHREADS=1 and the linker flag -lpthread.