### PR TITLE
Remove raw_ostream localmod

### DIFF
--- a/lib/IR/Module.cpp
+++ b/lib/IR/Module.cpp
@@ -22,7 +22,6 @@
 #include "llvm/IR/GVMaterializer.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/LLVMContext.h"
-#include "llvm/Support/raw_ostream.h" // XXX Emscripten TODO: Move to PNacl upstream.
 #include "llvm/IR/LeakDetector.h"
 #include "llvm/Support/Dwarf.h"
 #include "llvm/Support/Path.h"


### PR DESCRIPTION
This was added by @juj in e8fdaf5a2f09e335bdc5a6689b298e54337cc737 to fix the VS2010 build. It's either not needed anymore because the diff from LLVM upstream on this file is empty, or it's instead needed in upstream LLVM (I doubt it, since LLVM does build correcting on MSVC).