### PR TITLE
Remove build warning in ExpandInsertExtractElement

### DIFF
--- a/lib/Transforms/NaCl/ExpandInsertExtractElement.cpp
+++ b/lib/Transforms/NaCl/ExpandInsertExtractElement.cpp
@@ -55,11 +55,6 @@ INITIALIZE_PASS(ExpandInsertExtractElement, "expand-insert-extract-elements",
 
 // Utilities
 
-static Instruction *CopyDebug(Instruction *NewInst, Instruction *Original) {
-  NewInst->setDebugLoc(Original->getDebugLoc());
-  return NewInst;
-}
-
 bool ExpandInsertExtractElement::runOnFunction(Function &F) {
   Changed = false;
 
@@ -101,11 +96,6 @@ bool ExpandInsertExtractElement::runOnFunction(Function &F) {
   return Changed;
 }
 
-namespace llvm {
-
-FunctionPass *createExpandInsertExtractElementPass() {
+FunctionPass *llvm::createExpandInsertExtractElementPass() {
   return new ExpandInsertExtractElement();
 }
-
-}
-


### PR DESCRIPTION
CopyDebug is accessible now that ExpandInsertExtractElement includes NaCl.h. I'd rather use IRBuilder in general and remove CopyDebug in the future, but it'll ahve to do for now. Also merge in the change for the create* function.