### PR TITLE
Fully merge PromoteIntegers

### DIFF
--- a/lib/Transforms/NaCl/PromoteIntegers.cpp
+++ b/lib/Transforms/NaCl/PromoteIntegers.cpp
@@ -40,8 +40,6 @@
 using namespace llvm;
 
 namespace {
-class ConversionState;
-
 class PromoteIntegers : public FunctionPass {
 public:
   static char ID;
@@ -49,10 +47,6 @@ public:
     initializePromoteIntegersPass(*PassRegistry::getPassRegistry());
   }
   virtual bool runOnFunction(Function &F);
-  virtual void getAnalysisUsage(AnalysisUsage &AU) const {
-    AU.addRequired<DataLayoutPass>();
-    return FunctionPass::getAnalysisUsage(AU);
-  }
 };
 } // anonymous namespace
 


### PR DESCRIPTION
No need to forward declare ConversionState anymore.
No need for getAnalysisUsage on DataLayoutPass anymore: LLVM's handling of DataLayoutPass changed in teh last few months and runOnFunction now simply creates the DataLayout from the Module.