### PR TITLE
Clean up double initialization in opt.

### DIFF
--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -413,8 +413,6 @@ int main(int argc, char **argv) {
   initializeSimplifyStructRegSignaturesPass(Registry);
   initializeStripAttributesPass(Registry);
   initializeStripMetadataPass(Registry);
-  initializeExpandI64Pass(Registry);
-  initializeNoExitRuntimePass(Registry);
   initializeStripModuleFlagsPass(Registry);
   initializeStripTlsPass(Registry);
   initializeSubstituteUndefsPass(Registry);


### PR DESCRIPTION
I grouped Emscripten pass initialization lower, so the changes didn't merge conflict. I'll fix the double initialization of NoExitRuntime below in the PNaCl repo to reduce merging.