### PR TITLE
Add back a space that was removed in emscripten, is in LLVM.

### DIFF
--- a/configure
+++ b/configure
@@ -5521,6 +5521,7 @@ case "$withval" in
 esac
 EXTRA_LD_OPTIONS=$EXTRA_LD_OPTIONS
 
+
 # Check whether --enable-bindings was given.
 if test "${enable_bindings+set}" = set; then
   enableval=$enable_bindings;


### PR DESCRIPTION
This just makes our diff smaller.