### PR TITLE
Clean up CMakeLists.txt merge.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,9 +170,8 @@ set(LLVM_LIBDIR_SUFFIX "" CACHE STRING "Define suffix of library directory name 
 set(LLVM_ALL_TARGETS
   AArch64
   ARM
-  JSBackend
-  Hexagon
   CppBackend
+  Hexagon
   JSBackend # @LOCALMOD
   Mips
   MSP430


### PR DESCRIPTION
This is closer to LLVM's CMakeLists.txt, and has the localmod marker.