### PR TITLE
Remove extra vararg store alignment.

### DIFF
--- a/lib/Transforms/NaCl/ExpandVarArgs.cpp
+++ b/lib/Transforms/NaCl/ExpandVarArgs.cpp
@@ -243,10 +243,8 @@ static bool ExpandVarArgCall(Module *M, InstType *Call, DataLayout *DL) {
       IRB.CreateMemCpy(Ptr, Arg, DL->getTypeAllocSize(
                                      Arg->getType()->getPointerElementType()),
                        /*Align=*/1);
-    else {
-      StoreInst *S = IRB.CreateStore(Arg, Ptr);
-      S->setAlignment(4); // EMSCRIPTEN: pnacl stack is only 4-byte aligned
-    }
+    else
+      IRB.CreateStore(Arg, Ptr);
     ++Index;
   }
 


### PR DESCRIPTION
kripken added this in 6198caf1 but it's not needed anymore (and was incorrect): the code was putting varargs on the stack as a packed struct which caused misaligned reads and writes, I fixed the issue by making the struct non-packed and using the target's prefered alignment for each element instead. The alloca should be aligned to the target's preference too, so everything should now be neatly aligned. This pass runs pre-opt, so the optimizer can figure out the alignment of all the loads and stores and foster further harmony in the memory.