### PR TITLE
Remove ExpandVarArgs localmod.

### DIFF
--- a/lib/Transforms/NaCl/ExpandVarArgs.cpp
+++ b/lib/Transforms/NaCl/ExpandVarArgs.cpp
@@ -256,14 +256,8 @@ static bool ExpandVarArgCall(Module *M, InstType *Call, DataLayout *DL) {
   ArgTypes.push_back(VarArgsTy->getPointerTo());
   FunctionType *NFTy = FunctionType::get(FuncType->getReturnType(), ArgTypes,
                                          /*isVarArg=*/false);
-  /// XXX EMSCRIPTEN: Handle Constants as well as Instructions, since we
-  /// don't run the ConstantExpr lowering pass.
-  Value *CastFunc;
-  if (Constant *C = dyn_cast<Constant>(Call->getCalledValue()))
-    CastFunc = ConstantExpr::getBitCast(C, NFTy->getPointerTo());
-  else
-    CastFunc = IRB.CreateBitCast(Call->getCalledValue(),
-                                 NFTy->getPointerTo(), "vararg_func");
+  Value *CastFunc = IRB.CreateBitCast(Call->getCalledValue(),
+                                      NFTy->getPointerTo(), "vararg_func");
 
   // Create the converted function call.
   FixedArgs.push_back(Buf);


### PR DESCRIPTION
@sunfishcode added this change in 338da97e before ExpandVarArgs used IRBuilder. Now that it uses IRBuilder the change isn't needed because it'll automatically create constexprs when it can.