### PR TITLE
Emit debug info only when the line number is greater than 0.

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -635,7 +635,8 @@ static void emitDebugInfo(raw_ostream& Code, const Instruction *I) {
     DILocation Loc(N);
     unsigned Line = Loc.getLineNumber();
     StringRef File = Loc.getFilename();
-    Code << " //@line " << utostr(Line) << " \"" << (File.size() > 0 ? File.str() : "?") << "\"";
+    if (Line > 0)
+      Code << " //@line " << utostr(Line) << " \"" << (File.size() > 0 ? File.str() : "?") << "\"";
   }
 }
 


### PR DESCRIPTION
This PR is a bug fix for issue https://github.com/kripken/emscripten/issues/3401.