### PR TITLE
fix_uninit_bool_use

### DIFF
--- a/lib/Transforms/NaCl/PromoteIntegers.cpp
+++ b/lib/Transforms/NaCl/PromoteIntegers.cpp
@@ -635,7 +635,7 @@ static void convertInstruction(DataLayout *DL, Instruction *Inst,
 
 static bool processFunction(Function &F, DataLayout &DL) {
   ConversionState State;
-  bool Modified;
+  bool Modified = false; // XXX Emscripten: Fixed use of an uninitialized variable.
   for (auto FI = F.begin(), FE = F.end(); FI != FE; ++FI) {
     for (auto BBI = FI->begin(), BBE = FI->end(); BBI != BBE;) {
       Instruction *Inst = BBI++;


### PR DESCRIPTION
Emscripten: Fix use of an uninitialized boolean variable in lib/Transforms/NaCl/PromoteIntegers.cpp. Windows debug builds crash in this function a few lines down when runtime checks catch a load of `Modified`, and dump with a trace like

	0x00007FF7C2F3688D (0xCCCCCCCCCCCCCCCC 0xCCCCCCCCCCCCCCCC 0xCCCCCCCCCCCCCCCC 0xCCCCCCCCCCCCCCCC), failwithmessage() + 0x22D bytes(s), f:\dd\vctools\crt\crtw32\rtc\error.cpp, line 222
	0x00007FF7C2F369BF (0x00000098C33AE720 0x00007FF7C2F35D40 0xCCCCCCCC00000000 0xCCCCCCCCCCCCCCCC), _RTC_UninitUse() + 0xFF bytes(s), f:\dd\vctools\crt\crtw32\rtc\error.cpp, line 475
	0x00007FF7C240EB79 (0x00000098C35963E0 0x00000098C33AE8E0 0x00000098C5BD4E30 0x00000098C35D9C20), processFunction() + 0x229 bytes(s), c:\code\emsdk\clang\fastcomp\src\lib\transforms\nacl\promoteintegers.cpp, line 656 + 0x16 byte(s)
	0x00007FF7C240B7CA (0x00000098C5E02BD0 0x00000098C35D9C20 0x00000098C35D9C20 0xCCCCCCCC00000005), `anonymous namespace'::PromoteIntegers::runOnModule() + 0x20A bytes(s), c:\code\emsdk\clang\fastcomp\src\lib\transforms\nacl\promoteintegers.cpp, line 739 + 0x21 byte(s)
	0x00007FF7C2042611 (0x00000098C4F6A8F0 0x00000098C35D9C20 0xCCCCCCCCCCCCCCCC 0xCCCCCCCCCCCCCCCC), `anonymous namespace'::MPPassManager::runOnModule() + 0x311 bytes(s), c:\code\emsdk\clang\fastcomp\src\lib\ir\legacypassmanager.cpp, line 1616 + 0x40 byte(s)
	0x00007FF7C2042F04 (0x00000098C60795A0 0x00000098C35D9C20 0xCCCCCCCCCCCCCCCC 0xCCCCCCCCCCCCCCCC), llvm::legacy::PassManagerImpl::run() + 0x174 bytes(s), c:\code\emsdk\clang\fastcomp\src\lib\ir\legacypassmanager.cpp, line 1723 + 0x2A byte(s)
	0x00007FF7C203C136 (0x00000098C33AF288 0x00000098C35D9C20 0x00000098C33AF1B8 0x0000009800000000), llvm::legacy::PassManager::run() + 0x36 bytes(s), c:\code\emsdk\clang\fastcomp\src\lib\ir\legacypassmanager.cpp, line 1757
	0x00007FF7C161F0E9 (0x00007FF700000010 0x00000098C3596B60 0x0000000000000000 0x0000000000000000), main() + 0x24B9 bytes(s), c:\code\emsdk\clang\fastcomp\src\tools\opt\opt.cpp, line 758
	0x00007FF7C2F35C1D (0x0000000000000000 0x0000000000000000 0x0000000000000000 0x0000000000000000), __tmainCRTStartup() + 0x19D bytes(s), f:\dd\vctools\crt\crtw32\dllstuff\crtexe.c, line 626 + 0x19 byte(s)
	0x00007FF7C2F35D4E (0x0000000000000000 0x0000000000000000 0x0000000000000000 0x0000000000000000), mainCRTStartup() + 0xE bytes(s), f:\dd\vctools\crt\crtw32\dllstuff\crtexe.c, line 466
	0x00007FFA8AB413D2 (0x00007FFA8AB413B0 0x0000000000000000 0x0000000000000000 0x0000000000000000), BaseThreadInitThunk() + 0x22 bytes(s)
	0x00007FFA8D0D5454 (0x0000000000000000 0x0000000000000000 0x0000000000000000 0x0000000000000000), RtlUserThreadStart() + 0x34 bytes(s)
