### PR TITLE
Fix NaNs in SIMD

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -503,7 +503,7 @@ namespace {
       if (flt.getCategory() == APFloat::fcInfinity) return ensureCast(flt.isNegative() ? "-inf" : "inf", CFP->getType(), sign);
       else if (flt.getCategory() == APFloat::fcNaN) {
         APInt i = flt.bitcastToAPInt();
-        if ((i.getBitWidth() == 32 && i != APInt(32, 0x7FC00000)) || (i.getBitWidth() == 64 && i != APInt(64, 0x7FC0000000000000ULL))) {
+        if ((i.getBitWidth() == 32 && i != APInt(32, 0x7FC00000)) || (i.getBitWidth() == 64 && i != APInt(64, 0x7FF8000000000000ULL))) {
           // If we reach here, things have already gone bad, and JS engine NaN canonicalization will kill the bits in the float. However can't make
           // this a build error in order to not break people's existing code, so issue a warning instead.
           if (WarnOnNoncanonicalNans) {
@@ -1386,7 +1386,7 @@ std::string JSWriter::getConstantVector(const ConstantVectorType *C) {
 
   if (!isInt) {
     const APInt nan32(32, 0x7FC00000);
-    const APInt nan64(64, 0x7FC0000000000000ULL);
+    const APInt nan64(64, 0x7FF8000000000000ULL);
 
     for (unsigned i = 0; i < NumElts; ++i) {
       Constant *CV = VectorOperandAccessor<ConstantVectorType>::getOperand(C, i);

--- a/test/CodeGen/JS/simd-fcmp.ll
+++ b/test/CodeGen/JS/simd-fcmp.ll
@@ -6,7 +6,7 @@ target triple = "asmjs-unknown-emscripten"
 ; CHECK: function _test_ueq($a,$b) {
 ; CHECK: $a = SIMD_Float32x4_check($a);
 ; CHECK: $b = SIMD_Float32x4_check($b);
-; CHECK: SIMD_Float32x4_or(SIMD_Float32x4_or(SIMD_Float32x4_notEqual($a, $a), SIMD_Float32x4_notEqual($b, $b)), SIMD_Float32x4_equal($a, $b));
+; CHECK: $c = SIMD_Int32x4_notEqual(SIMD_Int32x4_or(SIMD_Int32x4_or(SIMD_Int32x4_select(SIMD_Float32x4_notEqual($a,$a), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0)),SIMD_Int32x4_select(SIMD_Float32x4_notEqual($b,$b), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0)),SIMD_Int32x4_select(SIMD_Float32x4_equal($a,$b), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0))), SIMD_Int32x4_splat(0));
 ; CHECK: return (SIMD_Int32x4_check($c));
 ; CHECK:}
 define <4 x i1> @test_ueq(<4 x float> %a, <4 x float> %b) {
@@ -17,7 +17,7 @@ define <4 x i1> @test_ueq(<4 x float> %a, <4 x float> %b) {
 ; CHECK: function _test_ord($a,$b) {
 ; CHECK: $a = SIMD_Float32x4_check($a);
 ; CHECK: $b = SIMD_Float32x4_check($b);
-; CHECK: SIMD_Float32x4_or(SIMD_Float32x4_or(SIMD_Float32x4_notEqual($a, $a), SIMD_Float32x4_notEqual($b, $b)), SIMD_Float32x4_equal($a, $b));
+; CHECK: $c = SIMD_Int32x4_notEqual(SIMD_Int32x4_or(SIMD_Int32x4_or(SIMD_Int32x4_select(SIMD_Float32x4_notEqual($a,$a), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0)),SIMD_Int32x4_select(SIMD_Float32x4_notEqual($b,$b), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0)),SIMD_Int32x4_select(SIMD_Float32x4_equal($a,$b), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0))), SIMD_Int32x4_splat(0));
 ; CHECK: return (SIMD_Int32x4_check($c));
 ; CHECK:}
 define <4 x i1> @test_ord(<4 x float> %a, <4 x float> %b) {
@@ -28,7 +28,7 @@ define <4 x i1> @test_ord(<4 x float> %a, <4 x float> %b) {
 ; CHECK:function _test_uno($a,$b) {
 ; CHECK: $a = SIMD_Float32x4_check($a);
 ; CHECK: $b = SIMD_Float32x4_check($b);
-; CHECK: SIMD_Float32x4_or(SIMD_Float32x4_or(SIMD_Float32x4_notEqual($a, $a), SIMD_Float32x4_notEqual($b, $b)), SIMD_Float32x4_equal($a, $b));
+; CHECK: $c = SIMD_Int32x4_notEqual(SIMD_Int32x4_or(SIMD_Int32x4_or(SIMD_Int32x4_select(SIMD_Float32x4_notEqual($a,$a), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0)),SIMD_Int32x4_select(SIMD_Float32x4_notEqual($b,$b), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0)),SIMD_Int32x4_select(SIMD_Float32x4_equal($a,$b), SIMD_Int32x4_splat(-1), SIMD_Int32x4_splat(0))), SIMD_Int32x4_splat(0));
 ; CHECK: return (SIMD_Int32x4_check($c));
 ; CHECK:}
 define <4 x i1> @test_uno(<4 x float> %a, <4 x float> %b) {

--- a/test/CodeGen/JS/simd-loadstore.ll
+++ b/test/CodeGen/JS/simd-loadstore.ll
@@ -7,7 +7,7 @@ target triple = "asmjs-unknown-emscripten"
 ; CHECK:  $p = $p|0;
 ; CHECK:  var $q = 0, $s = SIMD_Float32x4(0,0,0,0), $t = SIMD_Float32x4(0,0,0,0)
 ; CHECK:  $t = SIMD_Float32x4_load1(HEAPU8, $p);
-; CHECK:  $s = SIMD_Float32x4_add($t,SIMD_Float32x4(Math_fround(+0.5),Math_fround(+0),Math_fround(+0),Math_fround(+0)));
+; CHECK:  $s = SIMD_Float32x4_add($t,SIMD_Float32x4_splat(Math_fround(+0.5)));
 ; CHECK:  $q = $p;SIMD_Float32x4_store1(HEAPU8, $q, $s);
 ; CHECK:  return;
 ; CHECK: }

--- a/test/CodeGen/JS/simd-shuffle.ll
+++ b/test/CodeGen/JS/simd-shuffle.ll
@@ -46,7 +46,7 @@ entry:
 ; CHECK:  $a = SIMD_Float32x4_check($a);
 ; CHECK:  $b = SIMD_Float32x4_check($b);
 ; CHECK:  var $sel = SIMD_Float32x4(0,0,0,0)
-; CHECK:  $sel = SIMD_Float32x4_shuffle($a, $b, 7, 0, 0);
+; CHECK:  $sel = SIMD_Float32x4_shuffle($a, $b, 7, 0, 0, 0);
 ; CHECK:  return (SIMD_Float32x4_check($sel));
 ; CHECK: }
 define <3 x float> @shuffleXY_float32x4to3(<4 x float> %a, <4 x float> %b) nounwind {
@@ -124,7 +124,7 @@ entry:
 ; CHECK:  $a = SIMD_Int32x4_check($a);
 ; CHECK:  $b = SIMD_Int32x4_check($b);
 ; CHECK:  var $sel = SIMD_Int32x4(0,0,0,0)
-; CHECK:  $sel = SIMD_Int32x4_shuffle($a, $b, 6, 0, 5);
+; CHECK:  $sel = SIMD_Int32x4_shuffle($a, $b, 6, 0, 5, 0);
 ; CHECK:  return (SIMD_Int32x4_check($sel));
 ; CHECK: }
 define <3 x i32> @shuffle_int32x3(<3 x i32> %a, <3 x i32> %b) nounwind {
@@ -137,7 +137,7 @@ entry:
 ; CHECK:  $a = SIMD_Int32x4_check($a);
 ; CHECK:  $b = SIMD_Int32x4_check($b);
 ; CHECK:  var $sel = SIMD_Int32x4(0,0,0,0)
-; CHECK:  $sel = SIMD_Int32x4_shuffle($a, $b, 6, 0, 0);
+; CHECK:  $sel = SIMD_Int32x4_shuffle($a, $b, 6, 0, 0, 0);
 ; CHECK:  return (SIMD_Int32x4_check($sel));
 ; CHECK: }
 define <3 x i32> @shuffleXY_int32x3(<3 x i32> %a, <3 x i32> %b) nounwind {
@@ -254,7 +254,7 @@ entry:
 ; CHECK:  $a = SIMD_Int32x4_check($a);
 ; CHECK:  $b = SIMD_Int32x4_check($b);
 ; CHECK:  var $sel = SIMD_Int32x4(0,0,0,0)
-; CHECK:  $sel = SIMD_Int32x4_shuffle($a, $b, 7, 0, 5);
+; CHECK:  $sel = SIMD_Int32x4_shuffle($a, $b, 7, 0, 5, 0);
 ; CHECK:  return (SIMD_Int32x4_check($sel));
 ; CHECK: }
 define <3 x i32> @shuffle_int32x4to3(<4 x i32> %a, <4 x i32> %b) nounwind {
@@ -267,7 +267,7 @@ entry:
 ; CHECK:  $a = SIMD_Int32x4_check($a);
 ; CHECK:  $b = SIMD_Int32x4_check($b);
 ; CHECK:  var $sel = SIMD_Int32x4(0,0,0,0)
-; CHECK:  $sel = SIMD_Int32x4_shuffle($a, $b, 7, 0, 0);
+; CHECK:  $sel = SIMD_Int32x4_shuffle($a, $b, 7, 0, 0, 0);
 ; CHECK:  return (SIMD_Int32x4_check($sel));
 ; CHECK: }
 define <3 x i32> @shuffleXY_int32x4to3(<4 x i32> %a, <4 x i32> %b) nounwind {
@@ -384,7 +384,7 @@ entry:
 ; CHECK:  $a = SIMD_Float32x4_check($a);
 ; CHECK:  $b = SIMD_Float32x4_check($b);
 ; CHECK:  var $sel = SIMD_Float32x4(0,0,0,0)
-; CHECK:  $sel = SIMD_Float32x4_shuffle($a, $b, 6, 0, 5);
+; CHECK:  $sel = SIMD_Float32x4_shuffle($a, $b, 6, 0, 5, 0);
 ; CHECK:  return (SIMD_Float32x4_check($sel));
 ; CHECK: }
 define <3 x float> @shuffle_float32x3(<3 x float> %a, <3 x float> %b) nounwind {
@@ -397,7 +397,7 @@ entry:
 ; CHECK:  $a = SIMD_Float32x4_check($a);
 ; CHECK:  $b = SIMD_Float32x4_check($b);
 ; CHECK:  var $sel = SIMD_Float32x4(0,0,0,0)
-; CHECK:  $sel = SIMD_Float32x4_shuffle($a, $b, 6, 0, 0);
+; CHECK:  $sel = SIMD_Float32x4_shuffle($a, $b, 6, 0, 0, 0);
 ; CHECK:  return (SIMD_Float32x4_check($sel));
 ; CHECK: }
 define <3 x float> @shuffleXY_float32x3(<3 x float> %a, <3 x float> %b) nounwind {
@@ -514,7 +514,7 @@ entry:
 ; CHECK:  $a = SIMD_Float32x4_check($a);
 ; CHECK:  $b = SIMD_Float32x4_check($b);
 ; CHECK:  var $sel = SIMD_Float32x4(0,0,0,0)
-; CHECK:  $sel = SIMD_Float32x4_shuffle($a, $b, 7, 0, 5);
+; CHECK:  $sel = SIMD_Float32x4_shuffle($a, $b, 7, 0, 5, 0);
 ; CHECK:  return (SIMD_Float32x4_check($sel));
 ; CHECK: }
 define <3 x float> @shuffle_float32x4to3(<4 x float> %a, <4 x float> %b) nounwind {


### PR DESCRIPTION
When encountering float literals that have noncanonical NaN bit patterns in a SIMD vector, don't attempt to create a float SIMD vector directly out of them, since JS source can't represent NaNs with noncanonical bits. Instead, create an int SIMD vector and cast it to float one to detour to the SIMD vector with correct bits intact. Fixes https://github.com/kripken/emscripten/issues/2840,  https://github.com/kripken/emscripten/issues/3560, https://github.com/kripken/emscripten/issues/3010 and https://github.com/kripken/emscripten/issues/3403.