### PR TITLE
fix an unnecessary ad-hoc assign, which can mark a param as a UsedVar

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1987,7 +1987,7 @@ bool JSWriter::generateSIMDExpression(const User *I, raw_string_ostream& Code) {
       const Value *P = SI->getPointerOperand();
       std::string PS = getOpName(P);
       std::string VS = getValueAsStr(SI->getValueOperand());
-      Code << getAdHocAssign(PS, P->getType()) << getValueAsStr(P) << ';';
+      Code << PS << " = " << getValueAsStr(P) << ';';
       Code << "SIMD_" << simdType << "_store" << "(HEAPU8, " << PS << ", " << VS << ")";
       return true;
     } else if (Operator::getOpcode(I) == Instruction::ExtractElement) {


### PR DESCRIPTION
This fixes emscripten issue 3787. The problem began in 338da97ed47659b9ef04f60067f84cafc93e3dd3.

I assume this is the right fix, but since we have other SIMD breakage, I'm not sure I can trust the test suite, so not pushing this directly.