### PR TITLE
Allow multiple arities per EM_ASM block, fixes kripken/emscripten#3804.

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -126,7 +126,6 @@ namespace {
   typedef std::map<const Value*,std::string> ValueMap;
   typedef std::set<std::string> NameSet;
   typedef std::set<int> IntSet;
-  typedef std::set<int> OrderedIntSet;
   typedef std::vector<unsigned char> HeapData;
   typedef std::map<int, HeapData> HeapDataMap;
   typedef std::vector<int> AlignedHeapStartMap;
@@ -137,7 +136,7 @@ namespace {
   typedef std::map<std::string, FunctionTable> FunctionTableMap;
   typedef std::map<std::string, std::string> StringMap;
   typedef std::map<std::string, unsigned> NameIntMap;
-  typedef std::map<unsigned, OrderedIntSet> IntOrderedIntSetMap;
+  typedef std::map<unsigned, IntSet> IntIntSetMap;
   typedef std::map<const BasicBlock*, unsigned> BlockIndexMap;
   typedef std::map<const Function*, BlockIndexMap> BlockAddressMap;
   typedef std::map<const BasicBlock*, Block*> LLVMToRelooperMap;
@@ -167,7 +166,7 @@ namespace {
     StringMap Aliases;
     BlockAddressMap BlockAddresses;
     NameIntMap AsmConsts;
-    IntOrderedIntSetMap AsmConstArities;
+    IntIntSetMap AsmConstArities;
     NameSet FuncRelocatableExterns; // which externals are accessed in this function; we load them once at the beginning (avoids a potential call in a heap access, and might be faster)
 
     std::string CantValidate;
@@ -3131,14 +3130,14 @@ void JSWriter::printModuleBody() {
 
   Out << "\"asmConstArities\": {";
   first = true;
-  for (IntOrderedIntSetMap::const_iterator I = AsmConstArities.begin(), E = AsmConstArities.end();
+  for (IntIntSetMap::const_iterator I = AsmConstArities.begin(), E = AsmConstArities.end();
        I != E; ++I) {
     if (!first) {
       Out << ", ";
     }
     Out << "\"" << utostr(I->first) << "\": [";
     first = true;
-    for (OrderedIntSet::const_iterator J = I->second.begin(), F = I->second.end();
+    for (IntSet::const_iterator J = I->second.begin(), F = I->second.end();
          J != F; ++J) {
       if (first) {
         first = false;

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3128,6 +3128,14 @@ void JSWriter::printModuleBody() {
   }
   Out << "},";
 
+  // Output a structure like:
+  // "asmConstArities": {
+  //   "<ASM_CONST_ID_1>": [<ARITY>, <ARITY>],
+  //   "<ASM_CONST_ID_2>": [<ARITY>]
+  // }
+  // Each ASM_CONST_ID represents a single EM_ASM_* block in the code and each
+  // ARITY represents the number of arguments defined in the block in compiled
+  // output (which may vary, if the EM_ASM_* block is used inside a template).
   Out << "\"asmConstArities\": {";
   first = true;
   for (IntIntSetMap::const_iterator I = AsmConstArities.begin(), E = AsmConstArities.end();


### PR DESCRIPTION
PR for kripken/emscripten#3804.
Make a set of different arities in template expansions of each `EM_ASM` block.
They need to be ordered to take a shortcut in `emscripten.py` so there's a new typedef `OrderedIntSet` in case `IntSet` is later changed to `std::unordered_set`.