### PR TITLE
Fix compilation issue : “template specialization requires 'template<>'"

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1364,8 +1364,10 @@ class VectorOperandAccessor
 public:
   static Constant *getOperand(const VectorType *C, unsigned index);
 };
-template<> Constant *VectorOperandAccessor<ConstantVector>::getOperand(const ConstantVector *C, unsigned index) { return C->getOperand(index); }
-template<> Constant *VectorOperandAccessor<ConstantDataVector>::getOperand(const ConstantDataVector *C, unsigned index) { return C->getElementAsConstant(index); }
+template<>
+Constant *VectorOperandAccessor<ConstantVector>::getOperand(const ConstantVector *C, unsigned index) { return C->getOperand(index); }
+template<>
+Constant *VectorOperandAccessor<ConstantDataVector>::getOperand(const ConstantDataVector *C, unsigned index) { return C->getElementAsConstant(index); }
 
 template<typename ConstantVectorType/*= ConstantVector or ConstantDataVector*/>
 std::string JSWriter::getConstantVector(const ConstantVectorType *C) {

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1364,8 +1364,8 @@ class VectorOperandAccessor
 public:
   static Constant *getOperand(const VectorType *C, unsigned index);
 };
-Constant *VectorOperandAccessor<ConstantVector>::getOperand(const ConstantVector *C, unsigned index) { return C->getOperand(index); }
-Constant *VectorOperandAccessor<ConstantDataVector>::getOperand(const ConstantDataVector *C, unsigned index) { return C->getElementAsConstant(index); }
+template<> Constant *VectorOperandAccessor<ConstantVector>::getOperand(const ConstantVector *C, unsigned index) { return C->getOperand(index); }
+template<> Constant *VectorOperandAccessor<ConstantDataVector>::getOperand(const ConstantDataVector *C, unsigned index) { return C->getElementAsConstant(index); }
 
 template<typename ConstantVectorType/*= ConstantVector or ConstantDataVector*/>
 std::string JSWriter::getConstantVector(const ConstantVectorType *C) {


### PR DESCRIPTION
I encountered this issue while compiling clang-incoming-64bit on Linux