### PR TITLE
Say that bad SIMD types are completely unacceptable

### DIFF
--- a/lib/Target/JSBackend/JSTargetTransformInfo.h
+++ b/lib/Target/JSBackend/JSTargetTransformInfo.h
@@ -82,6 +82,11 @@ public:
       TTI::OperandValueProperties Opd2PropInfo = TTI::OP_None);
 
   unsigned getVectorInstrCost(unsigned Opcode, Type *Val, unsigned Index);
+
+  unsigned getMemoryOpCost(unsigned Opcode, Type *Src, unsigned Alignment,
+                           unsigned AddressSpace);
+
+  unsigned getCastInstrCost(unsigned Opcode, Type *Dst, Type *Src);
 };
 
 } // end namespace llvm


### PR DESCRIPTION
This adds some `TargetTransformInfo` logic to deny some bad SIMD types, seen when autovectorizing Bullet.

Btw, one of the things it tries is to vectorize things like `<4 x btVector3*>`, which I suppose we could support in theory, as it's just a 32-bit int.
