### PR TITLE
Handle bitcast of <4 x i32> to i128

### DIFF
--- a/lib/Transforms/NaCl/ExpandLargeIntegers.cpp
+++ b/lib/Transforms/NaCl/ExpandLargeIntegers.cpp
@@ -571,6 +571,29 @@ static void convertInstruction(Instruction *Inst, ConversionState &State,
     Value *Hi = IRB.CreateSelect(Cond, True.Hi, False.Hi, Twine(Name, ".hi"));
     State.recordConverted(Select, {Lo, Hi});
 
+  } else if (BitCastInst *BitCast = dyn_cast<BitCastInst>(Inst)) {
+    // XXX EMSCRIPTEN handle bitcast <4 x i32> to i128
+    Value *Input = BitCast->getOperand(0);
+    assert(Input->getType()->isVectorTy());
+    VectorType *VT = cast<VectorType>(Input->getType());
+    assert(VT->getNumElements() == 4 && VTy->getElementType()->isIntegerTy(32));
+
+    Type *I32 = Type::getInt32Ty(VT->getContext());
+    Value *P0 = IRB.CreateExtractElement(Input, ConstantInt::get(I32, 0), Twine(Name, ".p0"));
+    Value *P1 = IRB.CreateExtractElement(Input, ConstantInt::get(I32, 1), Twine(Name, ".p1"));
+    Value *P2 = IRB.CreateExtractElement(Input, ConstantInt::get(I32, 2), Twine(Name, ".p2"));
+    Value *P3 = IRB.CreateExtractElement(Input, ConstantInt::get(I32, 3), Twine(Name, ".p3"));
+
+    Type *I64 = Type::getInt64Ty(VT->getContext());
+    P0 = IRB.CreateZExt(P0, I64, Twine(Name, ".p0.64"));
+    P1 = IRB.CreateZExt(P1, I64, Twine(Name, ".p1.64"));
+    P2 = IRB.CreateZExt(P2, I64, Twine(Name, ".p2.64"));
+    P3 = IRB.CreateZExt(P3, I64, Twine(Name, ".p3.64"));
+
+    Value *Lo = IRB.CreateBinOp(Instruction::BinaryOps::Or, P0, IRB.CreateBinOp(Instruction::BinaryOps::Shl, P1, ConstantInt::get(I64, 32), Twine(Name, ".mid.lo")), Twine(Name, ".lo"));
+    Value *Hi = IRB.CreateBinOp(Instruction::BinaryOps::Or, P2, IRB.CreateBinOp(Instruction::BinaryOps::Shl, P3, ConstantInt::get(I64, 32), Twine(Name, ".mid.hi")), Twine(Name, ".hi"));
+    State.recordConverted(BitCast, {Lo, Hi});
+
   } else {
     DIE_IF(true, Inst, "Instruction");
   }


### PR DESCRIPTION
Possible fix for https://github.com/kripken/emscripten/issues/3789

GVN in the optimizer emits `  %2 = bitcast <4 x i32> %a to i128  ` to avoid a load from memory. There doesn't seem to be a way to tell GVN not do that.

This change adds support to lower that bitcast, by extracting the 4 elements into two i64s, which would then also be broken down later into legal i32s. This is probably not that fast in general, unless the optimizer is run and also manages to do something useful.