### PR TITLE
Prevent LLVM's optimizer from emitting silly vector types

### DIFF
--- a/lib/Transforms/Scalar/SROA.cpp
+++ b/lib/Transforms/Scalar/SROA.cpp
@@ -3996,8 +3996,8 @@ AllocaInst *SROA::rewritePartition(AllocaInst &AI, AllocaSlices &AS,
 
   bool IsIntegerPromotable = isIntegerWideningViable(P, SliceTy, DL);
 
-  VectorType *VecTy =
-      IsIntegerPromotable ? nullptr : isVectorPromotionViable(P, DL);
+  VectorType *VecTy = nullptr; // XXX EMSCRIPTEN - never promote to vectors
+      //IsIntegerPromotable ? nullptr : isVectorPromotionViable(P, DL); // waka
   if (VecTy)
     SliceTy = VecTy;
 


### PR DESCRIPTION
Fixes https://github.com/kripken/emscripten/issues/3788 and https://github.com/kripken/emscripten/issues/3789 , by modifing GVN and SROA to not emit vector types, and so avoid costly bitcasts for us.