### PR TITLE
Fix SIMD bool vector initializers

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2882,11 +2882,13 @@ void JSWriter::printFunctionBody(const Function *F) {
           // SIMD.js has only a fixed set of SIMD types, and no arbitrary vector sizes like <float x 3> or <i8 x 7>, so
           // codegen rounds up to the smallest appropriate size where the LLVM vector fits.
           unsigned simdJsNumElements = VT->getNumElements();
-          if (simdJsNumElements < 2 && VT->getElementType()->getPrimitiveSizeInBits() > 32) simdJsNumElements = 2;
-          else if (simdJsNumElements < 4 && VT->getElementType()->getPrimitiveSizeInBits() <= 32) simdJsNumElements = 4;
-          else if (simdJsNumElements < 8 && VT->getElementType()->getPrimitiveSizeInBits() <= 16) simdJsNumElements = 8;
-          else if (simdJsNumElements < 16 && VT->getElementType()->getPrimitiveSizeInBits() <= 8) simdJsNumElements = 16;
-
+          auto sizeInBits = VT->getElementType()->getPrimitiveSizeInBits();
+          if (sizeInBits > 1) {
+            if (simdJsNumElements < 2 && sizeInBits > 32) simdJsNumElements = 2;
+            else if (simdJsNumElements < 4 && sizeInBits <= 32) simdJsNumElements = 4;
+            else if (simdJsNumElements < 8 && sizeInBits <= 16) simdJsNumElements = 8;
+            else if (simdJsNumElements < 16 && sizeInBits <= 8) simdJsNumElements = 16;
+          }
           for (unsigned i = 1; i < simdJsNumElements; ++i) {
             Out << ",0";
           }


### PR DESCRIPTION
A few of the `asm1` simd tests produce output that fails to validate, like this in `asm1.test_simd3`
````
function _emscripten_float32x4_lessThan($__a,$__b) {
 $__a = SIMD_Float32x4_check($__a);
 $__b = SIMD_Float32x4_check($__b);
 var $0 = SIMD_Bool32x4(0,0,0,0,0,0,0,0), $1 = SIMD_Int32x4(0,0,0,0), label = 0, sp = 0;
````

Note the 8 parameters to the bool constructor. I suspect that in fully optimized code, we manage to get rid of the bool temporaries, and in completely unoptimized code we don't care about asm.js validation, so we only see this in `-O1`?

(similar stuff in `test_simd6 test_sse1 test_sse1_full`)

This is fixed by this commit. However, I'm not totally sure I get that code. In particular, why not have `<= 4` etc. instead of `< 4`, which might also fix this?