### PR TITLE
Avoid auto-declaring in call handlers

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3208,6 +3208,17 @@ void JSWriter::printModuleBody() {
           continue;
         }
       }
+      // Do not report methods implemented in a call handler, unless
+      // they are accessed by a function pointer (in which case, we
+      // need the expected name to be available TODO: optimize
+      // that out, call handlers can declare their "function table
+      // name").
+      std::string fullName = std::string("_") + I->getName().str();
+      if (CallHandlers.count(fullName) > 0) {
+        if (IndexedFunctions.find(fullName) == IndexedFunctions.end()) {
+          continue;
+        }
+      }
 
       if (first) {
         first = false;


### PR DESCRIPTION
This avoids unnecessary missing function stubs like you noticed in https://github.com/kripken/emscripten/issues/4068#issuecomment-179486581

See comment in the commit for more details.

It does come with the risk that if we forget to do a declare in a call handler, it can fail. But I think it's still worth it to avoid unnecessary code. Thoughts?