### PR TITLE
Add support for llvm.sin.f(32|64) intrinsics

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -791,6 +791,8 @@ DEF_BUILTIN_HANDLER(llvm_sqrt_f32, Math_sqrt);
 DEF_BUILTIN_HANDLER(llvm_sqrt_f64, Math_sqrt);
 DEF_BUILTIN_HANDLER(llvm_pow_f32, Math_pow); // XXX these will be slow in wasm, but need to link in libc before getting here, or stop
 DEF_BUILTIN_HANDLER(llvm_pow_f64, Math_pow); //     LLVM from creating these intrinsics
+DEF_MAYBE_BUILTIN_HANDLER(llvm_sin_f32, Math_sin);
+DEF_MAYBE_BUILTIN_HANDLER(llvm_sin_f64, Math_sin);
 
 DEF_CALL_HANDLER(llvm_powi_f32, {
   return getAssign(CI) + getParenCast("Math_pow(" + getValueAsCastStr(CI->getOperand(0)) + ", " + getCast(getValueAsCastStr(CI->getOperand(1)), CI->getOperand(0)->getType()) + ")", CI->getType());
@@ -2030,6 +2032,8 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(llvm_log_f64);
   SETUP_CALL_HANDLER(llvm_exp_f32);
   SETUP_CALL_HANDLER(llvm_exp_f64);
+  SETUP_CALL_HANDLER(llvm_sin_f32);
+  SETUP_CALL_HANDLER(llvm_sin_f64);
 }
 
 std::string handleCall(const Instruction *CI) {


### PR DESCRIPTION
This adds support for the llvm.sin.f(32|64) intrinsic to fastcomp. More details can be found in the issue kripken/emscripten#4338. The accompanying change to Emscripten is in pull request kripken/emscripten#4353