### PR TITLE
Fix Visual Studio 2015 build.

### DIFF
--- a/lib/Target/JSBackend/NaCl/NormalizeAlignment.cpp
+++ b/lib/Target/JSBackend/NaCl/NormalizeAlignment.cpp
@@ -59,8 +59,8 @@ bool NormalizeAlignment::runOnFunction(Function &F) {
   DataLayout DL(F.getParent());
   bool Modified = false;
 
-  for (BasicBlock &BB : F)
-    for (Instruction &I : BB)
+  for (BasicBlock &BB : F) {
+    for (Instruction &I : BB) {
       if (auto *MemOp = dyn_cast<MemIntrinsic>(&I)) {
         Modified = true;
         Type *AlignTy = MemOp->getAlignmentCst()->getType();
@@ -75,6 +75,8 @@ bool NormalizeAlignment::runOnFunction(Function &F) {
             &DL, Store->getAlignment(), Store->getValueOperand()->getType(),
             Store->isAtomic()));
       }
+    }
+  }
 
   return Modified;
 }

--- a/lib/Target/JSBackend/NaCl/SimplifyStructRegSignatures.cpp
+++ b/lib/Target/JSBackend/NaCl/SimplifyStructRegSignatures.cpp
@@ -572,8 +572,8 @@ bool SimplifyStructRegSignatures::runOnModule(Module &M) {
 void
 SimplifyStructRegSignatures::checkNoUnsupportedInstructions(LLVMContext &Ctx,
                                                             Function *Fct) {
-  for (auto &BB : Fct->getBasicBlockList())
-    for (auto &Inst : BB.getInstList())
+  for (auto &BB : Fct->getBasicBlockList()) {
+    for (auto &Inst : BB.getInstList()) {
       if (auto *Landing = dyn_cast<LandingPadInst>(&Inst)) {
         auto *LType = Fct->getPersonalityFn()->getType();
         if (LType != Mapper.getSimpleType(Ctx, LType)) {
@@ -589,6 +589,8 @@ SimplifyStructRegSignatures::checkNoUnsupportedInstructions(LLVMContext &Ctx,
               "Resumes with aggregate register signatures are not supported.");
         }
       }
+    }
+  }
 }
 ModulePass *llvm::createSimplifyStructRegSignaturesPass() {
   return new SimplifyStructRegSignatures();


### PR DESCRIPTION
Visual Studio 2015 Update 3 (latest version) gets confused by

    for (A B : C)
        if (x)
        else if (y)

and it complains that the `else` statement doesn't have a matching `if`. This has something to do with the modern style of `for` statement, at least in old style `for`s, the issue doesn't occur. Adding explicit block works around the problem.