### PR TITLE
wasm i64 support

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -586,7 +586,7 @@ DEF_CALL_HANDLER(llvm_ctlz_i64, {
     return CH___default__(CI, "i64_ctlz", 1);
   }
   Declares.insert("llvm_ctlz_i64");
-  return CH___default__(CI, "_llvm_ctlz_i64", 1);
+  return CH___default__(CI, "_llvm_ctlz_i64");
 })
 
 DEF_CALL_HANDLER(llvm_cttz_i64, {
@@ -594,7 +594,7 @@ DEF_CALL_HANDLER(llvm_cttz_i64, {
     return CH___default__(CI, "i64_cttz", 1);
   }
   Declares.insert("llvm_cttz_i64");
-  return CH___default__(CI, "_llvm_cttz_i64", 1);
+  return CH___default__(CI, "_llvm_cttz_i64");
 })
 
 DEF_CALL_HANDLER(llvm_maxnum_f32, {

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -582,12 +582,19 @@ DEF_CALL_HANDLER(llvm_cttz_i32, {
 })
 
 DEF_CALL_HANDLER(llvm_ctlz_i64, {
-  return CH___default__(CI, OnlyWebAssembly ? "i64_ctlz" : "_llvm_ctlz_i64", 1);
+  if (OnlyWebAssembly) {
+    return CH___default__(CI, "i64_ctlz", 1);
+  }
+  Declares.insert("llvm_ctlz_i64");
+  return CH___default__(CI, "_llvm_ctlz_i64", 1);
 })
 
 DEF_CALL_HANDLER(llvm_cttz_i64, {
-  Declares.insert("llvm_cttz_i32");
-  return CH___default__(CI, OnlyWebAssembly ? "i64_cttz" : "_llvm_cttz_i64", 1);
+  if (OnlyWebAssembly) {
+    return CH___default__(CI, "i64_cttz", 1);
+  }
+  Declares.insert("llvm_cttz_i64");
+  return CH___default__(CI, "_llvm_cttz_i64", 1);
 })
 
 DEF_CALL_HANDLER(llvm_maxnum_f32, {

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -581,6 +581,15 @@ DEF_CALL_HANDLER(llvm_cttz_i32, {
   return CH___default__(CI, "_llvm_cttz_i32", 1);
 })
 
+DEF_CALL_HANDLER(llvm_ctlz_i64, {
+  return CH___default__(CI, "i64_ctlz", 1);
+})
+
+DEF_CALL_HANDLER(llvm_cttz_i64, {
+  Declares.insert("llvm_cttz_i32");
+  return CH___default__(CI, "i64_cttz", 1);
+})
+
 DEF_CALL_HANDLER(llvm_maxnum_f32, {
   return CH___default__(CI, "Math_max", 2);
 })
@@ -1526,6 +1535,8 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(bitshift64Shl);
   SETUP_CALL_HANDLER(llvm_ctlz_i32);
   SETUP_CALL_HANDLER(llvm_cttz_i32);
+  SETUP_CALL_HANDLER(llvm_ctlz_i64);
+  SETUP_CALL_HANDLER(llvm_cttz_i64);
   SETUP_CALL_HANDLER(llvm_maxnum_f32);
   SETUP_CALL_HANDLER(llvm_maxnum_f64);
   SETUP_CALL_HANDLER(llvm_copysign_f32);

--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -582,12 +582,12 @@ DEF_CALL_HANDLER(llvm_cttz_i32, {
 })
 
 DEF_CALL_HANDLER(llvm_ctlz_i64, {
-  return CH___default__(CI, "i64_ctlz", 1);
+  return CH___default__(CI, OnlyWebAssembly ? "i64_ctlz" : "_llvm_ctlz_i64", 1);
 })
 
 DEF_CALL_HANDLER(llvm_cttz_i64, {
   Declares.insert("llvm_cttz_i32");
-  return CH___default__(CI, "i64_cttz", 1);
+  return CH___default__(CI, OnlyWebAssembly ? "i64_cttz" : "_llvm_cttz_i64", 1);
 })
 
 DEF_CALL_HANDLER(llvm_maxnum_f32, {

--- a/lib/Target/JSBackend/ExpandBigSwitches.cpp
+++ b/lib/Target/JSBackend/ExpandBigSwitches.cpp
@@ -24,12 +24,6 @@
 
 namespace llvm {
 
-/*
- * Find cases where an alloca is used only to load and store a single value,
- * even though it is bitcast. Then replace it with a direct alloca of that
- * simple type, and avoid the bitcasts.
- */
-
 struct ExpandBigSwitches : public FunctionPass {
   static char ID; // Pass identification, replacement for typeid
   ExpandBigSwitches() : FunctionPass(ID) {}

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1446,7 +1446,7 @@ std::string JSWriter::getConstant(const Constant* CV, AsmCast sign) {
     if (sign != ASM_UNSIGNED && CI->getValue().getBitWidth() == 1) {
       sign = ASM_UNSIGNED; // bools must always be unsigned: either 0 or 1
     }
-    if (!OnlyWebAssembly || CI->getType() == i32) {
+    if (!OnlyWebAssembly || CI->getValue().getBitWidth() < 64) {
       return CI->getValue().toString(10, sign != ASM_UNSIGNED);
     } else {
       // i64 constant. emit as 32 bits, 32 bits, for ease of parsing by a JS-style parser

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2468,6 +2468,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
                      (CmpInst::Predicate)cast<ConstantExpr>(I)->getPredicate() :
                      cast<ICmpInst>(I)->getPredicate();
     if (OnlyWebAssembly && I->getOperand(0)->getType()->getIntegerBitWidth() == 64) {
+      Code << getAssignIfNeeded(I);
       switch (predicate) {
         case ICmpInst::ICMP_EQ:  Code << "i64_eq(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
         case ICmpInst::ICMP_NE:  Code << "i64_ne(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2654,7 +2654,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   case Instruction::UIToFP:
   case Instruction::SIToFP: {
     Code << getAssignIfNeeded(I);
-    if (OnlyWebAssembly && (I->getOperand(0)->getType()->getIntegerBitWidth() == 64 || I->getOperand(1)->getType()->getIntegerBitWidth() == 64)) {
+    if (OnlyWebAssembly && (I->getType()->getIntegerBitWidth() == 64 || I->getOperand(0)->getType()->getIntegerBitWidth() == 64)) {
       switch (Operator::getOpcode(I)) {
         case Instruction::Trunc: {
           //unsigned inBits = V->getType()->getIntegerBitWidth();

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2665,9 +2665,8 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
          (I->getOperand(0)->getType()->isIntegerTy() && I->getOperand(0)->getType()->getIntegerBitWidth() == 64))) {
       switch (Operator::getOpcode(I)) {
         case Instruction::Trunc: {
-          //unsigned inBits = V->getType()->getIntegerBitWidth();
           unsigned outBits = I->getType()->getIntegerBitWidth();
-          Code << "i64_trunc(" << getValueAsStr(I->getOperand(0)) << ')'; break;
+          Code << "i64_trunc(" << getValueAsStr(I->getOperand(0)) << ')';
           if (outBits < 32) {
             Code << "&" << utostr(LSBMask(outBits));
           }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2281,7 +2281,8 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   assert(I == I->stripPointerCasts());
 
   Type *T = I->getType();
-  if (T->isIntegerTy() && T->getIntegerBitWidth() > 32 && !OnlyWebAssembly) {
+  if (T->isIntegerTy() && ((!OnlyWebAssembly && T->getIntegerBitWidth() > 32) ||
+                           ( OnlyWebAssembly && T->getIntegerBitWidth() > 64))) {
     errs() << *I << "\n";
     report_fatal_error("legalization problem");
   }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1124,6 +1124,9 @@ static const char *heapNameToAtomicTypeName(const char *HeapName)
 std::string JSWriter::getLoad(const Instruction *I, const Value *P, Type *T, unsigned Alignment, char sep) {
   std::string Assign = getAssign(I);
   unsigned Bytes = DL->getTypeAllocSize(T);
+  if (OnlyWebAssembly && Bytes == 8 && T->isIntegerTy()) {
+    return Assign + "i64_load(" + getValueAsStr(P) + "," + itostr(Alignment) + ")";
+  }
   std::string text;
   if (Bytes <= Alignment || Alignment == 0) {
     if (EnablePthreads && cast<LoadInst>(I)->isVolatile()) {
@@ -1242,6 +1245,9 @@ std::string JSWriter::getLoad(const Instruction *I, const Value *P, Type *T, uns
 std::string JSWriter::getStore(const Instruction *I, const Value *P, Type *T, const std::string& VS, unsigned Alignment, char sep) {
   assert(sep == ';'); // FIXME when we need that
   unsigned Bytes = DL->getTypeAllocSize(T);
+  if (OnlyWebAssembly && Bytes == 8 && T->isIntegerTy()) {
+    return "i64_store(" + getValueAsStr(P) + "," + VS + "," + itostr(Alignment) + ")";
+  }
   std::string text;
   if (Bytes <= Alignment || Alignment == 0) {
     if (EnablePthreads && cast<StoreInst>(I)->isVolatile()) {

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3005,11 +3005,11 @@ void JSWriter::printFunctionBody(const Function *F) {
           Out << "0";
           break;
         case Type::IntegerTyID:
-          if (VI->second == i32) {
-            Out << "0";
-          } else {
+          if (VI->second->getIntegerBitWidth() == 64) {
             assert(OnlyWebAssembly);
             Out << "i64()";
+          } else {
+            Out << "0";
           }
           break;
         case Type::FloatTyID:

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2642,6 +2642,11 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   }
   case Instruction::PtrToInt:
   case Instruction::IntToPtr:
+    if (OnlyWebAssembly && I->getOperand(0)->getType()->getIntegerBitWidth() == 64) {
+      // it is valid in LLVM IR to convert an i64 into a 32-bit pointer, it truncates
+      Code << getAssignIfNeeded(I) << "i64_trunc(" << getValueAsStr(I->getOperand(0)) << ')';
+      break;
+    }
     Code << getAssignIfNeeded(I) << getValueAsStr(I->getOperand(0));
     break;
   case Instruction::Trunc:

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -1005,6 +1005,7 @@ std::string JSWriter::getCast(const StringRef &s, Type *t, AsmCast sign) {
         case 8:  if (!(sign & ASM_NONSPECIFIC)) return sign == ASM_UNSIGNED ? (s + "&255").str()   : (s + "<<24>>24").str();
         case 16: if (!(sign & ASM_NONSPECIFIC)) return sign == ASM_UNSIGNED ? (s + "&65535").str() : (s + "<<16>>16").str();
         case 32: return (sign == ASM_SIGNED || (sign & ASM_NONSPECIFIC) ? s + "|0" : s + ">>>0").str();
+        case 64: return ("i64(" + s + ")").str();
         default: llvm_unreachable("Unsupported integer cast bitwidth");
       }
     }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -369,7 +369,7 @@ namespace {
           return 'F';
         }
       } else {
-        if (OnlyWebAssembly && T->getIntegerBitWidth() == 64) {
+        if (OnlyWebAssembly && T->isIntegerTy() && T->getIntegerBitWidth() == 64) {
           return 'j';
         } else {
           return 'i';
@@ -2332,7 +2332,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   case Instruction::AShr:{
     Code << getAssignIfNeeded(I);
     unsigned opcode = Operator::getOpcode(I);
-    if (OnlyWebAssembly && I->getType()->getIntegerBitWidth() == 64) {
+    if (OnlyWebAssembly && I->getType()->isIntegerTy() && I->getType()->getIntegerBitWidth() == 64) {
       switch (opcode) {
         case Instruction::Add:  Code << "i64_add(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
         case Instruction::Sub:  Code << "i64_sub(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
@@ -2468,7 +2468,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
     auto predicate = isa<ConstantExpr>(I) ?
                      (CmpInst::Predicate)cast<ConstantExpr>(I)->getPredicate() :
                      cast<ICmpInst>(I)->getPredicate();
-    if (OnlyWebAssembly && I->getOperand(0)->getType()->getIntegerBitWidth() == 64) {
+    if (OnlyWebAssembly && I->getOperand(0)->getType()->isIntegerTy() && I->getOperand(0)->getType()->getIntegerBitWidth() == 64) {
       Code << getAssignIfNeeded(I);
       switch (predicate) {
         case ICmpInst::ICMP_EQ:  Code << "i64_eq(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
@@ -2654,7 +2654,9 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
   case Instruction::UIToFP:
   case Instruction::SIToFP: {
     Code << getAssignIfNeeded(I);
-    if (OnlyWebAssembly && (I->getType()->getIntegerBitWidth() == 64 || I->getOperand(0)->getType()->getIntegerBitWidth() == 64)) {
+    if (OnlyWebAssembly &&
+        ((I->getType()->isIntegerTy() && I->getType()->getIntegerBitWidth() == 64) ||
+         (I->getOperand(0)->getType()->isIntegerTy() && I->getOperand(0)->getType()->getIntegerBitWidth() == 64))) {
       switch (Operator::getOpcode(I)) {
         case Instruction::Trunc: {
           //unsigned inBits = V->getType()->getIntegerBitWidth();

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2467,6 +2467,22 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
     auto predicate = isa<ConstantExpr>(I) ?
                      (CmpInst::Predicate)cast<ConstantExpr>(I)->getPredicate() :
                      cast<ICmpInst>(I)->getPredicate();
+    if (OnlyWebAssembly && I->getOperand(0)->getType()->getIntegerBitWidth() == 64) {
+      switch (predicate) {
+        case ICmpInst::ICMP_EQ:  Code << "i64_eq(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        case ICmpInst::ICMP_NE:  Code << "i64_ne(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        case ICmpInst::ICMP_ULE: Code << "i64_ule(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;;
+        case ICmpInst::ICMP_SLE: Code << "i64_sle(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        case ICmpInst::ICMP_UGE: Code << "i64_uge(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        case ICmpInst::ICMP_SGE: Code << "i64_sge(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        case ICmpInst::ICMP_ULT: Code << "i64_ult(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        case ICmpInst::ICMP_SLT: Code << "i64_slt(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        case ICmpInst::ICMP_UGT: Code << "i64_ugt(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        case ICmpInst::ICMP_SGT: Code << "i64_sgt(" << getValueAsStr(I->getOperand(0)) << "," << getValueAsStr(I->getOperand(1)) << ")"; break;
+        default: llvm_unreachable("Invalid ICmp-64 predicate");
+      }
+      break;
+    }
     AsmCast sign = CmpInst::isUnsigned(predicate) ? ASM_UNSIGNED : ASM_SIGNED;
     Code << getAssignIfNeeded(I) << "(" <<
       getValueAsCastStr(I->getOperand(0), sign) <<

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -369,10 +369,10 @@ namespace {
           return 'F';
         }
       } else {
-        if (T == i32) {
-          return 'i';
-        } else {
+        if (OnlyWebAssembly && T->getIntegerBitWidth() == 64) {
           return 'j';
+        } else {
+          return 'i';
         }
       }
     }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -4206,8 +4206,13 @@ bool JSTargetMachine::addPassesToEmitFile(
   // end PNaCl legalization
 
   PM.add(createExpandInsertExtractElementPass());
-  if (!OnlyWebAssembly) { // if only wasm, then we can emit i64s
+
+  if (!OnlyWebAssembly) {
+    // if only wasm, then we can emit i64s, otherwise they must be lowered
     PM.add(createExpandI64Pass());
+  } else {
+    // only wasm, and for now no atomics there, so just lower them out
+    PM.add(createLowerAtomicPass());
   }
 
   CodeGenOpt::Level OptLevel = getOptLevel();


### PR DESCRIPTION
This adds support for emitting i64 operations and values directly from the fastcomp backend. This is now possible since the binaryen wasm optimizer has made running the asm.js optimizer no longer necessary. Since we can now go straight from the backend into binaryen, we can keep i64s as i64s (by not running the ExpandI64 pass, and emitting a bunch of new `i64_*` intrinsics). The code is no longer valid asm.js, but that doesn't matter.

Of course we can only do this when we are in "wasm-only" mode, since sometimes we do expect to either run the asm.js, or we are actually running the asm.js optimizer (if either the user requested it explicitly, or an option the user requested mandates it). So this is behind a flag. But by default we should be able to pass that flag.

This started as an experiment, but turned out to be very easy to do. With wasm 0xc binary support we could benchmark this soon, should be benefits.

There will be corresponding binaryen and emscripten PRs (binaryen to parse the new `i64_*` intrinsics in `asm2wasm`, emscripten to pass the wasm-only flag).