### PR TITLE
More wasm-only opts

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2785,15 +2785,23 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
     Type *OutType = I->getType();
     std::string V = getValueAsStr(I->getOperand(0));
     if (InType->isIntegerTy() && OutType->isFloatingPointTy()) {
-      if (OnlyWebAssembly && InType->getIntegerBitWidth() == 64) {
-        Code << "i64_bc2d(" << V << ')';
+      if (OnlyWebAssembly) {
+        if (InType->getIntegerBitWidth() == 64) {
+          Code << "i64_bc2d(" << V << ')';
+        } else {
+          Code << "i32_bc2f(" << V << ')';
+        }
         break;
       }
       assert(InType->getIntegerBitWidth() == 32);
       Code << "(HEAP32[tempDoublePtr>>2]=" << V << "," << getCast("HEAPF32[tempDoublePtr>>2]", Type::getFloatTy(TheModule->getContext())) << ")";
     } else if (OutType->isIntegerTy() && InType->isFloatingPointTy()) {
-      if (OnlyWebAssembly && OutType->getIntegerBitWidth() == 64) {
-        Code << "i64_bc2i(" << V << ')';
+      if (OnlyWebAssembly) {
+        if (OutType->getIntegerBitWidth() == 64) {
+          Code << "i64_bc2i(" << V << ')';
+        } else {
+          Code << "i32_bc2i(" << V << ')';
+        }
         break;
       }
       assert(OutType->getIntegerBitWidth() == 32);

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -614,6 +614,14 @@ namespace {
       }
     }
 
+    std::string emitI64Const(uint64_t value) {
+      return "i64_const(" + itostr(value & uint32_t(-1)) + "," + itostr((value >> 32) & uint32_t(-1)) + ")";
+    }
+
+    std::string emitI64Const(APInt i) {
+      return emitI64Const(i.getZExtValue());
+    }
+
     std::string ftostr(const ConstantFP *CFP, AsmCast sign) {
       const APFloat &flt = CFP->getValueAPF();
 
@@ -1430,11 +1438,6 @@ std::string JSWriter::getPtrUse(const Value* Ptr) {
   const char *HeapName = 0;
   std::string Index = getHeapNameAndIndex(Ptr, &HeapName);
   return std::string(HeapName) + '[' + Index + ']';
-}
-
-static std::string emitI64Const(APInt i) {
-  auto value = i.getZExtValue();
-  return "i64_const(" + itostr(value & uint32_t(-1)) + "," + itostr((value >> 32) & uint32_t(-1)) + ")";
 }
 
 std::string JSWriter::getConstant(const Constant* CV, AsmCast sign) {


### PR DESCRIPTION
When in wasm-only mode, emit special intrinsics for loads, stores and bitcasts, to avoid asm.js limitations.