### PR TITLE
Binaryen dynamic linking

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -87,6 +87,10 @@ DEF_CALL_HANDLER(__default__, {
           Name = std::string(Relocatable ? "mftCall_" : "ftCall_") + Sig + "(" + getCast(Name, Type::getInt32Ty(CI->getContext()));
           if (NumArgs > 0) Name += ',';
           Emulated = true;
+          if (WebAssembly) {
+            // this call uses the wasm Table
+            NeedCasts = false;
+          }
         }
       }
     }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3378,13 +3378,13 @@ void JSWriter::printModuleBody() {
     } while (i < num);
     PostSets.clear();
     if (WebAssembly && SideModule) {
-      // emit the __start_module method for a wasm side module,
+      // emit the init method for a wasm side module,
       // which runs postsets and global inits
       // note that we can't use the wasm start mechanism, as the JS side is
       // not yet ready - imagine that in the start method we call out to JS,
       // then try to call back in, but we haven't yet captured the exports
       // from the wasm module to their places on the JS Module object etc.
-      Out << "function __start_module() {\n";
+      Out << "function __post_instantiate() {\n";
       if (StackSize > 0) {
         Out << " STACKTOP = " << relocateGlobal(utostr(getGlobalAddress("wasm-module-stack"))) << ";\n";
         Out << " STACK_MAX = STACKTOP + " << StackSize << " | 0;\n";
@@ -3395,7 +3395,7 @@ void JSWriter::printModuleBody() {
       }
       GlobalInitializers.clear();
       Out << "}\n";
-      Exports.push_back("__start_module");
+      Exports.push_back("__post_instantiate");
     }
   }
   Out << "// EMSCRIPTEN_END_FUNCTIONS\n\n";


### PR DESCRIPTION
This together with a binaryen and emscripten PR implement dynamic linking in wasm. This is done according to the recently-merged

https://github.com/WebAssembly/tool-conventions/blob/master/DynamicLinking.md

and in particular the dynamic library is a wasm module.

This fastcomp PR adds some fixes for using wasm tables more extensively, which is necessary for dynamic linking.