### PR TITLE
create a legalizer stub for imported methods with float32 params/return values that go in tables

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -484,6 +484,10 @@ namespace {
       // isn't an issue for i64s even though they are illegal, precisely because
       // f32/f64 overloading is possible but i64s don't overload in asm.js with
       // anything.
+      // TODO: if there are no uses of F (aside from being in the table) then
+      //       we don't need this, as we'll add a use in
+      //       DeclaresNeedingTypeDeclarations which will have the proper type,
+      //       and nothing will contradict it/overload it.
       if (WebAssembly && F->isDeclaration() && usesFloat32(F->getFunctionType())) {
         Table.push_back(makeFloat32Legalizer(F));
       } else {


### PR DESCRIPTION
As due to asm.js overloading of float/double, we can't legalize them later - we don't know the type of the indirect calls.

Noted in https://bugzilla.mozilla.org/show_bug.cgi?id=1334239#c14