### PR TITLE
Use streams instead of std::to_string

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -7,6 +7,8 @@
 // which are reported as declared but not implemented symbols, so that
 // JS linking brings them in.
 
+#include "llvm/Support/ScopedPrinter.h"
+
 typedef std::string (JSWriter::*CallHandler)(const Instruction*, std::string Name, int NumArgs);
 typedef std::map<std::string, CallHandler> CallHandlerMap;
 CallHandlerMap CallHandlers;
@@ -1039,7 +1041,7 @@ DEF_BUILTIN_HANDLER(emscripten_float32x4_abs, SIMD_Float32x4_abs);
 std::string castBoolVecToIntVec(int numElems, const std::string &str, bool signExtend)
 {
   int elemWidth = 128 / numElems;
-  std::string simdType = "SIMD_Int" + std::to_string(elemWidth) + "x" + std::to_string(numElems);
+  std::string simdType = "SIMD_Int" + llvm::to_string(elemWidth) + "x" + llvm::to_string(numElems);
   return simdType + "_select(" + str + ", " + simdType + "_splat(" + (signExtend ? "-1" : "1") + "), " + simdType + "_splat(0))";
 }
 DEF_CALL_HANDLER(emscripten_float32x4_lessThan, {

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -38,6 +38,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/Support/MathExtras.h"
+#include "llvm/Support/ScopedPrinter.h"
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/Transforms/IPO.h"
@@ -1924,7 +1925,7 @@ void JSWriter::generateExtractElementExpression(const ExtractElementInst *EEI, r
     Code << getAssignIfNeeded(EEI);
     std::string OperandCode;
     raw_string_ostream CodeStream(OperandCode);
-    CodeStream << std::string("SIMD_") << SIMDType(VT) << "_extractLane(" << getValueAsStr(EEI->getVectorOperand()) << ',' << std::to_string(Index) << ')';
+    CodeStream << std::string("SIMD_") << SIMDType(VT) << "_extractLane(" << getValueAsStr(EEI->getVectorOperand()) << ',' << Index << ')';
     Code << getCast(CodeStream.str(), EEI->getType());
     return;
   }
@@ -1936,7 +1937,7 @@ void JSWriter::generateExtractElementExpression(const ExtractElementInst *EEI, r
 std::string castIntVecToBoolVec(int numElems, const std::string &str)
 {
   int elemWidth = 128 / numElems;
-  std::string simdType = "SIMD_Int" + std::to_string(elemWidth) + "x" + std::to_string(numElems);
+  std::string simdType = "SIMD_Int" + to_string(elemWidth) + "x" + to_string(numElems);
   return simdType + "_notEqual(" + str + ", " + simdType + "_splat(0))";
 }
 


### PR DESCRIPTION
`std::to_string` is not available on freebsd 10, so use streams instead.

cc rust-lang/rust#40123 