### PR TITLE
Require re-running expansion after expanding to an array

### DIFF
--- a/lib/Target/JSBackend/NaCl/ExpandStructRegs.cpp
+++ b/lib/Target/JSBackend/NaCl/ExpandStructRegs.cpp
@@ -68,7 +68,9 @@ char ExpandStructRegs::ID = 0;
 INITIALIZE_PASS(ExpandStructRegs, "expand-struct-regs",
                 "Expand out variables with struct types", false, false)
 
-static bool DoAnotherPass(Type *Ty) { return isa<StructType>(Ty); }
+static bool DoAnotherPass(Type *Ty) {
+  return isa<StructType>(Ty) || isa<ArrayType>(Ty);
+}
 static bool DoAnotherPass(Value *V) { return DoAnotherPass(V->getType()); }
 
 static bool SplitUpPHINode(PHINode *Phi) {


### PR DESCRIPTION
Fixes #176.

When something like `struct Foo { int bar[10]; }` was expanded, this would generate `getelementptr` to the array `bar` and then a `load` from that pointer. The code failed to recognise that a `load` of an array needed to be further expanded, causing the assertion later.