### PR TITLE
emscripten-js-ffi opt to disable JS FFI mangling.

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -139,7 +139,7 @@ DEF_CALL_HANDLER(__default__, {
     if (NumArgs > 0) text += ",";
   }
   // this is an ffi call if we need casts, and it is not a special Math_ builtin or wasm-only intrinsic
-  bool FFI = NeedCasts;
+  bool FFI = LegalizeJavaScriptFFI && NeedCasts;
   if (FFI) {
     if (IsMath && (Name == "Math_ceil" || Name == "Math_floor" || Name == "Math_min" || Name == "Math_max" || Name == "Math_sqrt" || Name == "Math_abs")) {
       // This special Math builtin is optimizable with all types, including floats, so can treat it as non-ffi

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -113,6 +113,11 @@ Relocatable("emscripten-relocatable",
             cl::init(false));
 
 static cl::opt<bool>
+LegalizeJavaScriptFFI("emscripten-legalize-javascript-ffi",
+           cl::desc("Whether to legalize JavaScript FFI calls (see emscripten LEGALIZE_JS_FFI option)"),
+           cl::init(true));
+
+static cl::opt<bool>
 SideModule("emscripten-side-module",
            cl::desc("Whether to emit a side module (see emscripten SIDE_MODULE option)"),
            cl::init(false));


### PR DESCRIPTION
For JS/Web platform, calls to JS imports are wrapped to convert i64 to
i32 and f32 to f64. Likewise calls from JS into exports do the inverse
wrapping. However, for non-web embeddings this is probably undesirable.
This change provides an option to disable that wrapping and
use the original types for the call. This is used by emscripten with the JS_FFI option (https://github.com/kripken/emscripten/pull/5168). A related option is also proposed for binaryen (https://github.com/WebAssembly/binaryen/pull/984).