### PR TITLE
remove_atomics_exchange_polyfill

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3010,11 +3010,6 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
         // implemented, we could remove the emulation, but until then we must emulate manually.
         bool fround = PreciseF32 && !strcmp(HeapName, "HEAPF32");
         Code << Assign << (fround ? "Math_fround(" : "+") << "_emscripten_atomic_" << atomicFunc << "_" << heapNameToAtomicTypeName(HeapName) << "(" << getValueAsStr(P) << ", " << VS << (fround ? "))" : ")"); break;
-
-      // TODO: Remove the following two lines once https://bugzilla.mozilla.org/show_bug.cgi?id=1141986 is implemented!
-      } else if (rmwi->getOperation() == AtomicRMWInst::Xchg && !strcmp(HeapName, "HEAP32")) {
-        Code << Assign << "_emscripten_atomic_exchange_u32(" << getValueAsStr(P) << ", " << VS << ")|0"; break;
-
       } else {
         Code << Assign << "(Atomics_" << atomicFunc << "(" << HeapName << ", " << Index << ", " << VS << ")|0)"; break;
       }


### PR DESCRIPTION
Remove software implemented emscripten_atomic_exchange_u32() polyfill, which is not needed anymore since Atomics.exchange() is part of the spec and implemented in shipping browsers. https://github.com/kripken/emscripten/issues/3498

Merge with https://github.com/kripken/emscripten/pull/5438