### PR TITLE
Em asm calltype

### DIFF
--- a/lib/Target/JSBackend/NaCl/ExpandVarArgs.cpp
+++ b/lib/Target/JSBackend/NaCl/ExpandVarArgs.cpp
@@ -49,8 +49,7 @@ INITIALIZE_PASS(ExpandVarArgs, "expand-varargs",
 static bool isEmscriptenJSArgsFunc(Module *M, StringRef Name) {
   // TODO(jfb) Make these intrinsics in clang and remove the assert: these
   //           intrinsics should only exist for Emscripten.
-  bool isEmscriptenSpecial = Name.equals("emscripten_asm_const_int") ||
-                             Name.equals("emscripten_asm_const_double") ||
+  bool isEmscriptenSpecial = Name.startswith("emscripten_asm_const_") ||
                              Name.equals("emscripten_landingpad") ||
                              Name.equals("emscripten_resume");
   assert(isEmscriptenSpecial ? Triple(M->getTargetTriple()).isOSEmscripten()


### PR DESCRIPTION
This expands `EM_ASM` handling to allow specifying how the JS code is run in multithreaded environment: a) locally (synchronously) on the calling thread, b) synchronously proxied to main browser thread, or c) asynchronously proxied to main browser thread.

This needs a matching Emscripten side PR to land, I'll get to that at some point.