### PR TITLE
Fix VS2017 build error (cherry-picking from LLVM repo)

### DIFF
--- a/include/llvm/ADT/DenseSet.h
+++ b/include/llvm/ADT/DenseSet.h
@@ -104,7 +104,9 @@ public:
     Iterator(const typename MapTy::iterator &i) : I(i) {}
 
     ValueT &operator*() { return I->getFirst(); }
+    const ValueT &operator*() const { return I->getFirst(); }
     ValueT *operator->() { return &I->getFirst(); }
+    const ValueT *operator->() const { return &I->getFirst(); }
 
     Iterator& operator++() { ++I; return *this; }
     Iterator operator++(int) { auto T = *this; ++I; return T; }
@@ -125,8 +127,8 @@ public:
 
     ConstIterator(const typename MapTy::const_iterator &i) : I(i) {}
 
-    const ValueT &operator*() { return I->getFirst(); }
-    const ValueT *operator->() { return &I->getFirst(); }
+    const ValueT &operator*() const { return I->getFirst(); }
+    const ValueT *operator->() const { return &I->getFirst(); }
 
     ConstIterator& operator++() { ++I; return *this; }
     ConstIterator operator++(int) { auto T = *this; ++I; return T; }


### PR DESCRIPTION
Cherry-picking https://github.com/llvm-mirror/llvm/commit/fe78796b302967097ce983205c2f8450107cf948, fixes #185.

This will help VS2017 users before #191 lands.