### PR TITLE
Don't lower away atomics when building for wasm

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -4460,9 +4460,6 @@ bool JSTargetMachine::addPassesToEmitFile(
   if (!OnlyWebAssembly) {
     // if only wasm, then we can emit i64s, otherwise they must be lowered
     PM.add(createExpandI64Pass());
-  } else {
-    // only wasm, and for now no atomics there, so just lower them out
-    PM.add(createLowerAtomicPass());
   }
 
   CodeGenOpt::Level OptLevel = getOptLevel();


### PR DESCRIPTION
We can use them now.