### PR TITLE
Make lowerAtomic pass conditional on disabling pthreads

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -4460,6 +4460,8 @@ bool JSTargetMachine::addPassesToEmitFile(
   if (!OnlyWebAssembly) {
     // if only wasm, then we can emit i64s, otherwise they must be lowered
     PM.add(createExpandI64Pass());
+  } else if (!EnablePthreads) {
+    PM.add(createLowerAtomicPass());
   }
 
   CodeGenOpt::Level OptLevel = getOptLevel();


### PR DESCRIPTION
Atomics can then still be used in single-threaded codegen