### PR TITLE
Add llvm.minnum.f(32|64) and llvm.maxnum.f(32|64) intrinsics

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -697,14 +697,6 @@ DEF_CALL_HANDLER(llvm_ctpop_i64, {
   return CH___default__(CI, "_llvm_ctpop_i64");
 })
 
-DEF_CALL_HANDLER(llvm_maxnum_f32, {
-  return CH___default__(CI, "Math_max", 2);
-})
-
-DEF_CALL_HANDLER(llvm_maxnum_f64, {
-  return CH___default__(CI, "Math_max", 2);
-})
-
 DEF_CALL_HANDLER(llvm_copysign_f32, {
   if (OnlyWebAssembly) {
     return CH___default__(CI, "f32_copysign", 2);
@@ -975,6 +967,10 @@ DEF_MAYBE_BUILTIN_HANDLER(llvm_cos_f32, Math_cos);
 DEF_MAYBE_BUILTIN_HANDLER(llvm_cos_f64, Math_cos);
 DEF_MAYBE_BUILTIN_HANDLER(llvm_sin_f32, Math_sin);
 DEF_MAYBE_BUILTIN_HANDLER(llvm_sin_f64, Math_sin);
+DEF_MAYBE_BUILTIN_HANDLER(llvm_minnum_f32, Math_min);
+DEF_MAYBE_BUILTIN_HANDLER(llvm_minnum_f64, Math_min);
+DEF_MAYBE_BUILTIN_HANDLER(llvm_maxnum_f32, Math_max);
+DEF_MAYBE_BUILTIN_HANDLER(llvm_maxnum_f64, Math_max);
 
 DEF_CALL_HANDLER(llvm_powi_f32, {
   return getAssign(CI) + getParenCast("Math_pow(" + getValueAsCastStr(CI->getOperand(0)) + ", " + getCast(getValueAsCastStr(CI->getOperand(1)), CI->getOperand(0)->getType()) + ")", CI->getType());
@@ -1692,8 +1688,6 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(llvm_cttz_i64);
   SETUP_CALL_HANDLER(llvm_ctpop_i32);
   SETUP_CALL_HANDLER(llvm_ctpop_i64);
-  SETUP_CALL_HANDLER(llvm_maxnum_f32);
-  SETUP_CALL_HANDLER(llvm_maxnum_f64);
   SETUP_CALL_HANDLER(llvm_copysign_f32);
   SETUP_CALL_HANDLER(llvm_copysign_f64);
 
@@ -2237,6 +2231,10 @@ void setupCallHandlers() {
   SETUP_CALL_HANDLER(llvm_cos_f64);
   SETUP_CALL_HANDLER(llvm_sin_f32);
   SETUP_CALL_HANDLER(llvm_sin_f64);
+  SETUP_CALL_HANDLER(llvm_minnum_f32);
+  SETUP_CALL_HANDLER(llvm_minnum_f64);
+  SETUP_CALL_HANDLER(llvm_maxnum_f32);
+  SETUP_CALL_HANDLER(llvm_maxnum_f64);
 }
 
 std::string handleCall(const Instruction *CI) {


### PR DESCRIPTION
The corresponding change to Emscripten is this PR:
https://github.com/kripken/emscripten/pull/5978, and relates to this
issue: https://github.com/kripken/emscripten/issues/5976. I’m using
https://github.com/kripken/emscripten-fastcomp/pull/143 as a model.