### PR TITLE
Remove 2-alignment on reserved function pointers

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -425,7 +425,8 @@ namespace {
         Sig = "X";
       }
       FunctionTable &Table = FunctionTables[Sig];
-      unsigned MinSize = ReservedFunctionPointers ? 2*(ReservedFunctionPointers+1) : 1; // each reserved slot must be 2-aligned
+      unsigned MinSize =
+          ReservedFunctionPointers ? ReservedFunctionPointers + 1 : 1;
       while (Table.size() < MinSize) Table.push_back("0");
       return Table;
     }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -425,8 +425,7 @@ namespace {
         Sig = "X";
       }
       FunctionTable &Table = FunctionTables[Sig];
-      unsigned MinSize =
-          ReservedFunctionPointers ? ReservedFunctionPointers + 1 : 1;
+      unsigned MinSize = ReservedFunctionPointers + 1;
       while (Table.size() < MinSize) Table.push_back("0");
       return Table;
     }


### PR DESCRIPTION
According to kripken/emscripten#6068, it is not necessary anymore.