### PR TITLE
don't emit clz/ctz/pop intrinsics as declared functions

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3653,6 +3653,9 @@ void JSWriter::printModuleBody() {
         case Intrinsic::memmove:
         case Intrinsic::expect:
         case Intrinsic::flt_rounds:
+        case Intrinsic::ctlz:
+        case Intrinsic::cttz:
+        case Intrinsic::ctpop:
           continue;
         }
       }


### PR DESCRIPTION
The callhandler already handles them properly. This removes a little bit of unnecessary code that we were emitting.