### PR TITLE
Fix case where a unary operator is applied to a negative floating point literal.

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2632,7 +2632,7 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
       case Instruction::FSub:
         // LLVM represents an fneg(x) as -0.0 - x.
         if (BinaryOperator::isFNeg(I)) {
-          Code << ensureFloat("-" + getValueAsStr(BinaryOperator::getFNegArgument(I)), I->getType());
+          Code << ensureFloat("- " + getValueAsStr(BinaryOperator::getFNegArgument(I)), I->getType());
         } else {
           Code << ensureFloat(getValueAsStr(I->getOperand(0)) + " - " + getValueAsStr(I->getOperand(1)), I->getType());
         }


### PR DESCRIPTION
This would produce code that was parsed as a prefix decrement operator. A space between both minus signs is enough for it to be interpreted correctly.

There test case for this is here: https://github.com/kripken/emscripten/pull/6228