### PR TITLE
stop warning about very large numbers of local variables

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3303,14 +3303,6 @@ void JSWriter::printFunctionBody(const Function *F) {
     nl(Out);
   }
 
-  {
-    static bool Warned = false;
-    if (!Warned && OptLevel < 2 && UsedVars.size() > 2000) {
-      prettyWarning() << "emitted code will contain very large numbers of local variables, which is bad for performance (build to JS with -O2 or above to avoid this - make sure to do so both on source files, and during 'linking')\n";
-      Warned = true;
-    }
-  }
-
   // Emit stack entry
   Out << " " << getAdHocAssign("sp", i32) << "STACKTOP;";
   if (uint64_t FrameSize = Allocas.getFrameSize()) {


### PR DESCRIPTION
JS VMs do a lot better on that these days anyhow, and even more so in wasm.