### PR TITLE
Export function pointers for wasm shared modules with emulated function pointers

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3934,17 +3934,19 @@ void JSWriter::printModuleBody() {
   }
 
   // for wasm shared emulated function pointers, we need to know a function pointer for each function name
-  Out << ", \"functionPointers\": {";
-  first = true;
-  for (auto& I : IndexedFunctions) {
-    if (first) {
-      first = false;
-    } else {
-      Out << ", ";
+  if (WebAssembly && Relocatable && EmulatedFunctionPointers) {
+    Out << ", \"functionPointers\": {";
+    first = true;
+    for (auto& I : IndexedFunctions) {
+      if (first) {
+        first = false;
+      } else {
+        Out << ", ";
+      }
+      Out << "\"" << I.first << "\": " << utostr(I.second) << "";
     }
-    Out << "\"" << I.first << "\": " << utostr(I.second) << "";
+    Out << "}";
   }
-  Out << "}";
 
   Out << "\n}\n";
 }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3371,6 +3371,13 @@ void JSWriter::printFunctionBody(const Function *F) {
   if (Relocatable) {
     if (!F->hasInternalLinkage()) {
       Exports.push_back(getJSName(F));
+      // In wasm shared module mode with emulated function pointers, put all exported functions in the table. That lets us
+      // use a simple i64-based ABI for everything, using function pointers for dlsym etc. (otherwise, if we used an
+      // export which is callable by JS - not using the i64 ABI - that would not be a proper function pointer for
+      // a wasm->wasm call).
+      if (WebAssembly && EmulatedFunctionPointers) {
+        getFunctionIndex(F);
+      }
     }
   }
 }
@@ -3925,6 +3932,19 @@ void JSWriter::printModuleBody() {
     }
     Out << "}\n}";
   }
+
+  // for wasm shared emulated function pointers, we need to know a function pointer for each function name
+  Out << ", \"functionPointers\": {";
+  first = true;
+  for (auto& I : IndexedFunctions) {
+    if (first) {
+      first = false;
+    } else {
+      Out << ", ";
+    }
+    Out << "\"" << I.first << "\": " << utostr(I.second) << "";
+  }
+  Out << "}";
 
   Out << "\n}\n";
 }


### PR DESCRIPTION
This makes sure that in that mode we have a function pointer for each export, and adds some extra metadata to describe it. It will be useful in https://github.com/kripken/emscripten/issues/6309 where we are trying to get emulation fully working with wasm.