### PR TITLE
retire RELOOPERDLL_API to fix MinGW shared build

### DIFF
--- a/lib/Target/JSBackend/Relooper.cpp
+++ b/lib/Target/JSBackend/Relooper.cpp
@@ -1,8 +1,3 @@
-// We are implementing the Relooper C API, so always export from this file.
-#ifndef RELOOPERDLL_EXPORTS
-#define RELOOPERDLL_EXPORTS
-#endif
-
 #include "Relooper.h"
 
 #include <string.h>
@@ -1352,7 +1347,7 @@ VoidIntMap __blockDebugMap__; // maps block pointers in currently running code t
 
 extern "C" {
 
-RELOOPERDLL_API void rl_set_output_buffer(char *buffer, int size) {
+void rl_set_output_buffer(char *buffer, int size) {
 #if DEBUG
   printf("#include \"Relooper.h\"\n");
   printf("int main() {\n");
@@ -1362,15 +1357,15 @@ RELOOPERDLL_API void rl_set_output_buffer(char *buffer, int size) {
   Relooper::SetOutputBuffer(buffer, size);
 }
 
-RELOOPERDLL_API void rl_make_output_buffer(int size) {
+void rl_make_output_buffer(int size) {
   Relooper::SetOutputBuffer((char*)malloc(size), size);
 }
 
-RELOOPERDLL_API void rl_set_asm_js_mode(int on) {
+void rl_set_asm_js_mode(int on) {
   Relooper::SetAsmJSMode(on);
 }
 
-RELOOPERDLL_API void *rl_new_block(const char *text, const char *branch_var) {
+void *rl_new_block(const char *text, const char *branch_var) {
   Block *ret = new Block(text, branch_var);
 #if DEBUG
   printf("  void *b%d = rl_new_block(\"// code %d\");\n", ret->Id, ret->Id);
@@ -1380,21 +1375,21 @@ RELOOPERDLL_API void *rl_new_block(const char *text, const char *branch_var) {
   return ret;
 }
 
-RELOOPERDLL_API void rl_delete_block(void *block) {
+void rl_delete_block(void *block) {
 #if DEBUG
   printf("  rl_delete_block(block_map[%d]);\n", ((Block*)block)->Id);
 #endif
   delete (Block*)block;
 }
 
-RELOOPERDLL_API void rl_block_add_branch_to(void *from, void *to, const char *condition, const char *code) {
+void rl_block_add_branch_to(void *from, void *to, const char *condition, const char *code) {
 #if DEBUG
   printf("  rl_block_add_branch_to(block_map[%d], block_map[%d], %s%s%s, %s%s%s);\n", ((Block*)from)->Id, ((Block*)to)->Id, condition ? "\"" : "", condition ? condition : "NULL", condition ? "\"" : "", code ? "\"" : "", code ? code : "NULL", code ? "\"" : "");
 #endif
   ((Block*)from)->AddBranchTo((Block*)to, condition, code);
 }
 
-RELOOPERDLL_API void *rl_new_relooper() {
+void *rl_new_relooper() {
 #if DEBUG
   printf("  void *block_map[10000];\n");
   printf("  void *rl = rl_new_relooper();\n");
@@ -1402,18 +1397,18 @@ RELOOPERDLL_API void *rl_new_relooper() {
   return new Relooper;
 }
 
-RELOOPERDLL_API void rl_delete_relooper(void *relooper) {
+void rl_delete_relooper(void *relooper) {
   delete (Relooper*)relooper;
 }
 
-RELOOPERDLL_API void rl_relooper_add_block(void *relooper, void *block) {
+void rl_relooper_add_block(void *relooper, void *block) {
 #if DEBUG
   printf("  rl_relooper_add_block(rl, block_map[%d]);\n", ((Block*)block)->Id);
 #endif
   ((Relooper*)relooper)->AddBlock((Block*)block);
 }
 
-RELOOPERDLL_API void rl_relooper_calculate(void *relooper, void *entry) {
+void rl_relooper_calculate(void *relooper, void *entry) {
 #if DEBUG
   printf("  rl_relooper_calculate(rl, block_map[%d]);\n", ((Block*)entry)->Id);
   printf("  rl_relooper_render(rl);\n");
@@ -1425,7 +1420,7 @@ RELOOPERDLL_API void rl_relooper_calculate(void *relooper, void *entry) {
   ((Relooper*)relooper)->Calculate((Block*)entry);
 }
 
-RELOOPERDLL_API void rl_relooper_render(void *relooper) {
+void rl_relooper_render(void *relooper) {
   ((Relooper*)relooper)->Render();
 }
 

--- a/lib/Target/JSBackend/Relooper.h
+++ b/lib/Target/JSBackend/Relooper.h
@@ -344,31 +344,21 @@ struct Debugging {
 
 // C API - useful for binding to other languages
 
-#ifdef _WIN32
-  #ifdef RELOOPERDLL_EXPORTS
-    #define RELOOPERDLL_API __declspec(dllexport)
-  #else
-    #define RELOOPERDLL_API __declspec(dllimport)
-  #endif
-#else
-  #define RELOOPERDLL_API
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-RELOOPERDLL_API void  rl_set_output_buffer(char *buffer, int size);
-RELOOPERDLL_API void  rl_make_output_buffer(int size);
-RELOOPERDLL_API void  rl_set_asm_js_mode(int on);
-RELOOPERDLL_API void *rl_new_block(const char *text, const char *branch_var);
-RELOOPERDLL_API void  rl_delete_block(void *block);
-RELOOPERDLL_API void  rl_block_add_branch_to(void *from, void *to, const char *condition, const char *code);
-RELOOPERDLL_API void *rl_new_relooper();
-RELOOPERDLL_API void  rl_delete_relooper(void *relooper);
-RELOOPERDLL_API void  rl_relooper_add_block(void *relooper, void *block);
-RELOOPERDLL_API void  rl_relooper_calculate(void *relooper, void *entry);
-RELOOPERDLL_API void  rl_relooper_render(void *relooper);
+void  rl_set_output_buffer(char *buffer, int size);
+void  rl_make_output_buffer(int size);
+void  rl_set_asm_js_mode(int on);
+void *rl_new_block(const char *text, const char *branch_var);
+void  rl_delete_block(void *block);
+void  rl_block_add_branch_to(void *from, void *to, const char *condition, const char *code);
+void *rl_new_relooper();
+void  rl_delete_relooper(void *relooper);
+void  rl_relooper_add_block(void *relooper, void *block);
+void  rl_relooper_calculate(void *relooper, void *entry);
+void  rl_relooper_render(void *relooper);
 
 #ifdef __cplusplus
 }

--- a/tools/opt/CMakeLists.txt
+++ b/tools/opt/CMakeLists.txt
@@ -8,9 +8,6 @@ set(LLVM_LINK_COMPONENTS
   IPO
   IRReader
   Linker
-  # @LOCALMOD-BEGIN
-  JSBackend
-  # @LOCALMOD-END
   InstCombine
   Instrumentation
   MC


### PR DESCRIPTION
With __declspec(dllexport), only the relooper APIs will be exported in the final DLL when building with MinGW. As a result, the shared build(-DBUILD_SHARED_LIBS=ON) breaks because LLVMJSBackendCodeGen.dll is not exporting all necessary symbols. The patch simply removes this
attribute. MSVC static build is supposed to be unaffected because the relooper APIs now go in LLVMJSBackendCodeGen.lib the same way as other LLVM symbols, and MSVC shared build is just not supported by LLVM.