### PR TITLE
fix_frem_for_precise_f32

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -2668,7 +2668,10 @@ void JSWriter::generateExpression(const User *I, raw_string_ostream& Code) {
       case Instruction::FAdd: Code << ensureFloat(getValueAsStr(I->getOperand(0)) + " + " + getValueAsStr(I->getOperand(1)), I->getType()); break;
       case Instruction::FMul: Code << ensureFloat(getValueAsStr(I->getOperand(0)) + " * " + getValueAsStr(I->getOperand(1)), I->getType()); break;
       case Instruction::FDiv: Code << ensureFloat(getValueAsStr(I->getOperand(0)) + " / " + getValueAsStr(I->getOperand(1)), I->getType()); break;
-      case Instruction::FRem: Code << ensureFloat(getValueAsStr(I->getOperand(0)) + " % " + getValueAsStr(I->getOperand(1)), I->getType()); break;
+      case Instruction::FRem:
+        if (PreciseF32 && !I->getType()->isDoubleTy()) Code << ensureFloat("+(" + getValueAsStr(I->getOperand(0)) + ") % +(" + getValueAsStr(I->getOperand(1)) + ")", I->getType());
+        else Code << ensureFloat(getValueAsStr(I->getOperand(0)) + " % " + getValueAsStr(I->getOperand(1)), I->getType());
+        break;
       case Instruction::FSub:
         // LLVM represents an fneg(x) as -0.0 - x.
         if (BinaryOperator::isFNeg(I)) {


### PR DESCRIPTION
Fix FRem handling for single precision floats so that it validates as asm.js.

For code

```c
float x = ...;
fmodf(x, 3.14f);
```

fastcomp is now generating

```
$3 = Math_fround($2 % Math_fround(3.1400001));
```

yielding

```
TypeError: asm.js type error: modulo cannot receive float arguments
```

This changes the code to emit

```
$3 = Math_fround(+($2) % +(Math_fround(3.1400001)));
```

so that it validates properly.

Unity is currently hitting this in asm.js builds, in really old code that has not changed in years. I don't know why this all of a sudden misvalidates - perhaps LLVM update changes `fmodf` to no longer go to a function call to musl? Or Firefox behavior change? (Firefox 61.0.1 (64-bit) on Windows gives the error)