### PR TITLE
Receive EMULATED_FUNCTION_POINTER_CASTS

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -98,6 +98,11 @@ EmulatedFunctionPointers("emscripten-emulated-function-pointers",
                          cl::desc("Emulate function pointers, avoiding asm.js function tables (see emscripten EMULATED_FUNCTION_POINTERS option)"),
                          cl::init(false));
 
+static cl::opt<bool>
+EmulateFunctionPointerCasts("emscripten-emulate-function-pointer-casts",
+                         cl::desc("Emulate function pointers casts, handling extra or ignored parameters (see emscripten EMULATE_FUNCTION_POINTER_CASTS option)"),
+                         cl::init(false));
+
 static cl::opt<int>
 EmscriptenAssertions("emscripten-assertions",
                      cl::desc("Additional JS-specific assertions (see emscripten ASSERTIONS)"),
@@ -3404,12 +3409,11 @@ void JSWriter::printFunctionBody(const Function *F) {
 
   if (Relocatable) {
     if (!F->hasInternalLinkage()) {
-      Exports.push_back(getJSName(F));
       // In wasm shared module mode with emulated function pointers, put all exported functions in the table. That lets us
       // use a simple i64-based ABI for everything, using function pointers for dlsym etc. (otherwise, if we used an
       // export which is callable by JS - not using the i64 ABI - that would not be a proper function pointer for
       // a wasm->wasm call).
-      if (WebAssembly && EmulatedFunctionPointers) {
+      if (WebAssembly && EmulateFunctionPointerCasts) {
         getFunctionIndex(F);
       }
     }

--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -3409,6 +3409,7 @@ void JSWriter::printFunctionBody(const Function *F) {
 
   if (Relocatable) {
     if (!F->hasInternalLinkage()) {
+      Exports.push_back(getJSName(F));
       // In wasm shared module mode with emulated function pointers, put all exported functions in the table. That lets us
       // use a simple i64-based ABI for everything, using function pointers for dlsym etc. (otherwise, if we used an
       // export which is callable by JS - not using the i64 ABI - that would not be a proper function pointer for


### PR DESCRIPTION
We did not handle this properly before, without this option, we looked at the similarly-named function pointer emulation flag.

Matched with https://github.com/kripken/emscripten/pull/7318