### PR TITLE
output_used_invoke_functions

### DIFF
--- a/lib/Target/JSBackend/CallHandlers.h
+++ b/lib/Target/JSBackend/CallHandlers.h
@@ -125,6 +125,7 @@ DEF_CALL_HANDLER(__default__, {
   if (Invoke) {
     Sig = getFunctionSignature(FT);
     Name = "invoke_" + Sig;
+    rememberUsedInvokeFunction(Name);
     NeedCasts = true;
   }
   std::string text = Name;


### PR DESCRIPTION
Output used invoke functions from fastcomp so that only the invoke_() functions that are needed can be generated.

It looks like `emscript_wasm_backend` function already referred to a `invoke_funcs = metadata.get('invokeFuncs', [])` field, with this contents, so adding the same to fastcomp side as well.