### PR TITLE
Emit helper functions callable by ftCall_<sig> for non-legal signatur…

### DIFF
--- a/lib/Target/JSBackend/JSBackend.cpp
+++ b/lib/Target/JSBackend/JSBackend.cpp
@@ -518,7 +518,7 @@ namespace {
       }
       LegalFunc += Call + ";\n}";
       ExtraFunctions.push_back(LegalFunc);
-	  return LegalName;
+      return LegalName;
     }
     // Return a function which can be used to indirectly invoke wasm functions from js
     void makeFtCallHelper(const Function *F) {


### PR DESCRIPTION
…es in wasm+emulated function pointers mode.

The ftCall_<sig> functions emitted in JS don't work for signatures containing i64 types since they
directly call the wasm function through the function table:
```
function ftCall_j(x) {
  return Module['wasmTable'].get(x)();
}
```
Calling this will lead to an error like:
exception thrown: TypeError: cannot pass i64 to or from JS,ftCall_j@a.out.js:2222:10

With this change, ftCall_j can be implemented as:
```
function ftCall_j(x) {
  return Module['asm']['ftCall_helper_j'](x);
}
```
Part of the fix for:
https://github.com/kripken/emscripten/issues/7399